### PR TITLE
Bugfix so when we have an invalid file it returns the proper code:

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "prepack": "npm run clean && npm run compile && oclif-dev manifest && oclif-dev readme",
     "pretest": "npm run lint",
     "lint": "eslint \"**/*.ts\" --quiet --fix",
+    "test:debug": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" --require ts-node/register --watch-extensions ts",
     "test": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" --require ts-node/register --watch-extensions ts --reporter=xunit --reporter-options output=reports/generator.xml",
     "version": "oclif-dev readme && git add README.md"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export default class RamlToolkitCommand extends Command {
       // eslint-disable-next-line no-await-in-loop
       promises.push(
         validateFile(arg, flags.profile).then(results => {
+          if (results.conforms === false) {
+            exitCode += 1;
+          }
           return printResults(results, flags.warnings);
         })
       );

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -9,7 +9,11 @@
 
 import path from "path";
 import { expect, test } from "@oclif/test";
-import { getSingleValidFile, getSingleInvalidFile } from "./utils.test";
+import {
+  getSingleValidFile,
+  getSingleInvalidFile,
+  getSlightlyInvalidFile
+} from "./utils.test";
 import { rename } from "fs-extra";
 
 import cmd from "../src";
@@ -130,6 +134,20 @@ describe("raml-toolkit cli", () => {
     )
     .exit(1)
     .it("validates one valid and one invalid file and exits non-zero");
+
+  test
+    .stdout()
+    .stderr()
+    .do(() =>
+      cmd.run([
+        "--profile",
+        MERCURY_PROFILE,
+        getSingleValidFile(),
+        getSlightlyInvalidFile()
+      ])
+    )
+    .exit(1)
+    .it("validates one valid and one slightly invalid file and exits non-zero");
 
   test
     .stdout()

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -77,3 +77,9 @@ export function getSingleInvalidFile(): string {
   fs.writeFileSync(tmpFile, "");
   return tmpFile;
 }
+
+export function getSlightlyInvalidFile(): string {
+  const doc = getHappySpec();
+  doc.version = "v1.1";
+  return renderSpecAsFile(doc);
+}


### PR DESCRIPTION
If an api didn't conform we were still returning a 0 exit code.  Only if it couldn't load the file at all was it returning a non-zero exit code. 