### PR TITLE
Logger for raml-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4532,6 +4532,11 @@
         }
       }
     },
+    "loglevel": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "tmp": "^0.1.0",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5",
-    "unzipper": "^0.10.10"
+    "unzipper": "^0.10.10",
+    "loglevel": "^1.6.8"
   },
   "lint-staged": {
     "*.ts": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,3 +96,4 @@ export { groupByCategory } from "./exchange-connector/exchangeTools";
 export { extractFiles } from "./exchange-connector/exchangeDirectoryParser";
 
 export { RestApi } from "./exchange-connector/exchangeTypes";
+export { ramlToolLogger } from "./logger";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as log from "loglevel";
+
+const RAML_TOOL_LOGGER_KEY = "RAML_TOOL_LOGGER";
+
+const ramlToolLogger = log.getLogger(RAML_TOOL_LOGGER_KEY);
+ramlToolLogger.setLevel(log.levels.INFO);
+
+export { RAML_TOOL_LOGGER_KEY, ramlToolLogger };

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as chai from "chai";
+import * as log from "loglevel";
+import { ramlToolLogger, RAML_TOOL_LOGGER_KEY } from "../src/logger";
+
+describe("Test log level", () => {
+  it("Test default log level", async () => {
+    return chai.expect(ramlToolLogger.getLevel()).to.equal(log.levels.INFO);
+  });
+  it("Test default log level with getLogger function", async () => {
+    return chai
+      .expect(log.getLogger(RAML_TOOL_LOGGER_KEY).getLevel())
+      .to.equal(log.levels.INFO);
+  });
+  it("Test log level change", async () => {
+    ramlToolLogger.setLevel(ramlToolLogger.levels.DEBUG);
+    return chai.expect(ramlToolLogger.getLevel()).to.equal(log.levels.DEBUG);
+  });
+});


### PR DESCRIPTION
Added logger using loglevel npm package

**Using logger inside the tool to log mesaages**
```javascript
import { ramlToolLogger } from "../logger";
ramlToolLogger.info("info message");
```