### PR TITLE
Use last index of exchange_modules/ as the URI path

### DIFF
--- a/src/exchange-connector/resourceLoader/fatRamlResourceLoader.ts
+++ b/src/exchange-connector/resourceLoader/fatRamlResourceLoader.ts
@@ -45,7 +45,7 @@ export class FatRamlResourceLoader implements amf.resource.ResourceLoader {
     const resourceAbsolutePath = path.join(
       this.workingDir,
       EXCHANGE_MODULES,
-      resourceUriParts[1]
+      resourceUriParts[resourceUriParts.length - 1]
     );
 
     try {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -39,11 +39,11 @@ export async function validateModel(
 export async function parseRaml(
   filename: string
 ): Promise<amf.model.document.BaseUnit> {
-  const ccStandardResourceLoader = new FatRamlResourceLoader(
+  const fatRamlResourceLoader = new FatRamlResourceLoader(
     path.dirname(filename)
   );
   const ccEnvironment = amf.client.DefaultEnvironment.apply().addClientLoader(
-    ccStandardResourceLoader
+    fatRamlResourceLoader
   );
   const parser = new amf.Raml10Parser(ccEnvironment);
 

--- a/test/exchange-connector/resourceLoader/fatRamlResourceLoader.test.ts
+++ b/test/exchange-connector/resourceLoader/fatRamlResourceLoader.test.ts
@@ -165,7 +165,9 @@ describe("Fat raml resource loader fetch tests", () => {
     );
     fatRamlResourceLoader.fsAdapter.readFileSync.returns("content");
     return fatRamlResourceLoader
-      .fetch("first_level/exchange_modules/second_level/exchange_modules/resource.json")
+      .fetch(
+        "first_level/exchange_modules/second_level/exchange_modules/resource.json"
+      )
       .then(function(s) {
         sinon.assert.calledWith(
           fatRamlResourceLoader.fsAdapter.readFileSync,

--- a/test/exchange-connector/resourceLoader/fatRamlResourceLoader.test.ts
+++ b/test/exchange-connector/resourceLoader/fatRamlResourceLoader.test.ts
@@ -157,6 +157,24 @@ describe("Fat raml resource loader fetch tests", () => {
       });
   });
 
+  it("Resolved for resources with 2 exchange_modules/ in path that are successfully read", () => {
+    const content = new amf.client.remote.Content(
+      "content",
+      "file:///workingDir/exchange_modules/resource.json",
+      "application/yaml"
+    );
+    fatRamlResourceLoader.fsAdapter.readFileSync.returns("content");
+    return fatRamlResourceLoader
+      .fetch("first_level/exchange_modules/second_level/exchange_modules/resource.json")
+      .then(function(s) {
+        sinon.assert.calledWith(
+          fatRamlResourceLoader.fsAdapter.readFileSync,
+          "/workingDir/exchange_modules/resource.json"
+        );
+        return expect(s).to.eql(content);
+      });
+  });
+
   it("Rejected for undefined resource paths", () => {
     return fatRamlResourceLoader.fetch(undefined).catch(function(err) {
       sinon.assert.notCalled(fatRamlResourceLoader.fsAdapter.readFileSync);


### PR DESCRIPTION
PR contains the fix for multiple exchange_modules/ in the fat RAML resource path