### PR TITLE
Update mercury profile to use the new AMF vocabulary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
+            - run: npm ci
       - run: npm run test
       - store_test_results:
           path: reports

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Salesforce.com, Inc.
+Copyright (c) 2020, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/bin/run
+++ b/bin/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
       }
     },
     "amf-client-js": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-3.5.4.tgz",
-      "integrity": "sha512-w+sDGeMQTLszKOiJKOl8CkvbRTv1+vPogQe/SziqdsptMP8NDqXM+VtJ258ZosrX9sseYb72UQwTlxvmanhsLA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.1.0.tgz",
+      "integrity": "sha512-uJuM6RQFbLM2epXZLfAzuXYFfF+4OY49Wx3TuJEls3auCnM+d0+5mNMfb06p0J7/uOyJAujX7/sQp1MS0tdcbw==",
       "requires": {
         "ajv": "6.5.2",
         "amf-shacl-node": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   "license": "BSD 3-Clause",
   "dependencies": {
     "@oclif/command": "^1.5.19",
+    "@oclif/config": "^1.13.3",
     "lodash": "^4.17.15",
-    "amf-client-js": "^3.5.4",
+    "amf-client-js": "^4.0.4",
     "express": "^4.17.1",
     "fs-extra": "^8.1.0",
     "js-yaml": "^3.13.1",

--- a/profiles/mercury.raml
+++ b/profiles/mercury.raml
@@ -32,14 +32,14 @@ validations:
 
   at-least-one-2xx-or-3xx-response:
     message: Methods must have at least one 2xx or 3xx response
-    targetClass: hydra.Operation
+    targetClass: apiContract.Operation
     functionConstraint:
       code: |
         function(method) {
           const re = /[23][0-9][0-9]/;
-          let returns = (method["hydra:returns"] || []);
+          let returns = (method["apiContract:returns"] || []);
           for (let i = 0; i < returns.length; i++) {
-            if (re.test(returns[i]["hydra:statusCode"])) {
+            if (re.test(returns[i]["apiContract:statusCode"])) {
               return true;
             }
           }
@@ -48,24 +48,24 @@ validations:
 
   camelcase-method-displayname:
     message: The API Method must have displayName and the value must be in camelcase
-    targetClass: hydra.Operation
+    targetClass: apiContract.Operation
     propertyConstraints: 
-      schema.name:
+      core.name:
           minCount: 1
           pattern: ^[a-z]+([A-Z]?[a-z0-9]+)*$
 
   camelcase-query-parameters:
     message: Query parameters names must be in camelcase
-    targetClass: http.Parameter
+    targetClass: apiContract.Parameter
     functionConstraint:
       code: |
         function(parameter) {
           const re = /^[a-z]+([A-Z]?[a-z0-9]+)*$/;
 
           // Parameters include query, path and headers so we need to check binding to filter
-          if (parameter['http:binding'] &&
-              parameter['http:binding'] == 'query' &&
-              !re.test(parameter['schema:name'])
+          if (parameter['apiContract:binding'] &&
+              parameter['apiContract:binding'] == 'query' &&
+              !re.test(parameter['core:name'])
           ) {
             return false;
           }
@@ -74,17 +74,17 @@ validations:
 
   https-required:
     message: Protocol MUST be HTTPS
-    targetClass: schema.WebAPI
+    targetClass: apiContract.WebAPI
     propertyConstraints:
-      http.scheme:
+      apiContract.scheme:
         in: [https,HTTPS]
         minCount: 1
 
   require-api-description:
     message: The API Description must be set
-    targetClass: schema.WebAPI
+    targetClass: apiContract.WebAPI
     propertyConstraints:
-      schema.description:
+      core.description:
         minCount: 1
 
   no-literal-question-marks-in-property-names:
@@ -102,9 +102,9 @@ validations:
       Query parameter, path parameter and header names must not contain question marks when 'required' is present. Using both results in names that include literal question marks.
 
       More info: https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#property-declarations
-    targetClass: http.Parameter
+    targetClass: apiContract.Parameter
     propertyConstraints:
-      schema.name:
+      core.name:
         pattern: ^[^?]*$
 
   no-todo-text-in-description-fields:
@@ -115,8 +115,8 @@ validations:
         function(resource) {
           const todoRegex = /\b(todo(_)*)\b|^\s*$/i;
           //doc.DomainElement may not have a description field, return true
-          if ( resource['schema:description']
-            && todoRegex.test(resource['schema:description'][0])  ) {
+          if ( resource['core:description']
+            && todoRegex.test(resource['core:description'][0])  ) {
             return false;
           }
           return true;
@@ -124,38 +124,38 @@ validations:
 
   require-method-description:
     message: The API Method description must be set
-    targetClass: hydra.Operation
+    targetClass: apiContract.Operation
     propertyConstraints:
-      schema.description:
+      core.description:
         minCount: 1
 
   require-response-description:
     message: The description for API responses must be set
-    targetClass: http.Response
+    targetClass: apiContract.Response
     propertyConstraints:
-      schema.description:
+      core.description:
         minCount: 1
 
   require-json:
     message: Require the API Spec's default mediaType to be application/json
-    targetClass: schema.WebAPI
+    targetClass: apiContract.WebAPI
     propertyConstraints:
-      http.accepts:
+      apiContract.accepts:
         in: ["application/json"]
         minCount: 1
 
   resource-name-validation:
     message: Resource endpoints must be lowercase (Mercury only)
-    targetClass: http.EndPoint
+    targetClass: apiContract.EndPoint
     propertyConstraints:
-      http.path:
+      apiContract.path:
         pattern: "(\/[a-z]([a-z0-9-])*[a-z0-9]+$)|(\/{[a-zA-Z0-9-]+}$)"
 
   version-format:
     message: The version must be formatted as v[Major], for example v2
-    targetClass: schema.WebAPI
+    targetClass: apiContract.WebAPI
     propertyConstraints:
-      schema.version:
+      core.version:
         pattern: ^v[0-9]+$
         minCount: 1
 

--- a/src/exchange-connector/bearerToken.ts
+++ b/src/exchange-connector/bearerToken.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/exchange-connector/exchangeDirectoryParser.ts
+++ b/src/exchange-connector/exchangeDirectoryParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/exchange-connector/exchangeDownloader.ts
+++ b/src/exchange-connector/exchangeDownloader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/exchange-connector/exchangeTypes.ts
+++ b/src/exchange-connector/exchangeTypes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/exchange-connector/index.ts
+++ b/src/exchange-connector/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/exchange-connector/bearerToken.test.ts
+++ b/test/exchange-connector/bearerToken.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/exchange-connector/exchangeDirectoryParser.test.ts
+++ b/test/exchange-connector/exchangeDirectoryParser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/exchange-connector/exchangeDownloader.test.ts
+++ b/test/exchange-connector/exchangeDownloader.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/exchange-connector/exchangeTools.test.ts
+++ b/test/exchange-connector/exchangeTools.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/mercury/camelcase-method-displayname.test.ts
+++ b/test/mercury/camelcase-method-displayname.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/mercury/camelcase-query-parameters.test.ts
+++ b/test/mercury/camelcase-query-parameters.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/mercury/mercury-profile.test.ts
+++ b/test/mercury/mercury-profile.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/mercury/no-literal-question-marks-in-parameters.test.ts
+++ b/test/mercury/no-literal-question-marks-in-parameters.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/mercury/no-literal-question-marks-in-property-names.test.ts
+++ b/test/mercury/no-literal-question-marks-in-property-names.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -44,10 +44,8 @@ export function breaksOnlyOneRule(
   rule: string
 ): void {
   assert.equal(result.conforms, false, result.toString());
-  if (!result.conforms) {
-    assert.equal(result.results.length, 1, result.toString());
-    assert.equal(result.results[0].validationId, rule, result.toString());
-  }
+  assert.equal(result.results.length, 1, result.toString());
+  assert.equal(result.results[0].validationId, rule, result.toString());
 }
 
 export function breaksTheseRules(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -44,8 +44,10 @@ export function breaksOnlyOneRule(
   rule: string
 ): void {
   assert.equal(result.conforms, false, result.toString());
-  assert.equal(result.results.length, 1, result.toString());
-  assert.equal(result.results[0].validationId, rule, result.toString());
+  if (!result.conforms) {
+    assert.equal(result.results.length, 1, result.toString());
+    assert.equal(result.results[0].validationId, rule, result.toString());
+  }
 }
 
 export function breaksTheseRules(


### PR DESCRIPTION
- Update the amf-client version to 4.0.4
- Update mercury profile to use the new AMF vocabulary
- Replace npm install with npm ci
- Change copyright year to 2020
