### PR TITLE
Br/baseuriparameter only shortcode.w 7275821

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 .vscode
 .env
 reports
+commerce-apps-raml-toolkit*.tgz

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The default profile validates the following rules from the [Mercury API Definiti
 * `queryParameters` MUST be camelCase
 * Response codes MUST have a `description`
 * Response codes `description` MUST NOT contain the word TODO
+* baseUriParameter section MUST only have shortCode
 
 ## Contributing
 

--- a/profiles/mercury.raml
+++ b/profiles/mercury.raml
@@ -15,6 +15,7 @@ disabled:
 
 violation:
   - at-least-one-2xx-or-3xx-response
+  - baseuriparameters-must-only-have-shortcode
   - camelcase-method-displayname
   - camelcase-query-parameters
   - https-required
@@ -44,6 +45,27 @@ validations:
             }
           }
           return false;
+        }
+
+  # baseUriParameters are either implicit when they only appear in the baseUri template
+  # or explicit when they are declared in the baseUriParameters. When parsed, they show up the same.
+  # Version is special parameter and should be allowed in the template.
+  # Here we really check that we have shortCode definitely and version maybe.
+  baseuriparameters-must-only-have-shortcode:
+    message: baseUriParameter section *MUST* only have shortCode
+    targetClass: apiContract.WebAPI
+    functionConstraint:
+      code: |
+        function(webapi) {
+          const isShortCode = (variable) => variable["core:name"][0] === "shortCode";
+          const isShortCodeOrVersion = (variable) => ["shortCode", "version"].includes(variable["core:name"][0]);
+
+          return webapi["apiContract:server"].every((server) => { 
+            const includesShortCode = server["apiContract:variable"].some(isShortCode);
+            const isOnlyShortCodeOrVersion = server["apiContract:variable"].every(isShortCodeOrVersion);
+
+            return includesShortCode && isOnlyShortCodeOrVersion;
+          });
         }
 
   camelcase-method-displayname:

--- a/test/mercury.raml
+++ b/test/mercury.raml
@@ -5,6 +5,11 @@ version: v1
 mediaType: application/json
 protocols: https
 description: This is a description of the API spec
+baseUri: https://{shortCode}.api.commercecloud.salesforce.com/checkout/shopper-orders/{version}
+baseUriParameters:
+  shortCode:
+    description: Region-specific merchant identifier.
+    example: fd4gt8
 
 types:
     ClassA:

--- a/test/mercury/baseuriparameters.test.ts
+++ b/test/mercury/baseuriparameters.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable no-undef */
+"use strict";
+import { validateFile } from "../../src/validator";
+import {
+  getHappySpec,
+  conforms,
+  breaksOnlyOneRule,
+  renderSpecAsFile
+} from "../utils.test";
+
+const PROFILE = "mercury";
+
+describe("baseUriParameters checking tests", () => {
+  it("conforms when shortCode is only baseUriParameter", async () => {
+    const doc = getHappySpec();
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+    conforms(result);
+  });
+
+  it("does not conform when shortCode is missing from baseUriParameters", async () => {
+    const doc = getHappySpec();
+    // We have to change the baseUri because it's implicit if it appears in the template
+    doc["baseUri"] = "https://example.com";
+    delete doc["baseUriParameters"]["shortCode"];
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+    breaksOnlyOneRule(
+      result,
+      "http://a.ml/vocabularies/data#baseuriparameters-must-only-have-shortcode"
+    );
+  });
+
+  it("does not conform with additional baseUriParameters", async () => {
+    const doc = getHappySpec();
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/checkout/shopper-orders/{version}/{anotherParameter}";
+    doc["baseUriParameters"]["anotherParameter"] = {
+      description: "my additional parameter",
+      example: "hello"
+    };
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+    breaksOnlyOneRule(
+      result,
+      "http://a.ml/vocabularies/data#baseuriparameters-must-only-have-shortcode"
+    );
+  });
+});

--- a/test/mercury/baseuriparameters.test.ts
+++ b/test/mercury/baseuriparameters.test.ts
@@ -49,4 +49,19 @@ describe("baseUriParameters checking tests", () => {
       "http://a.ml/vocabularies/data#baseuriparameters-must-only-have-shortcode"
     );
   });
+
+  it("does not conform with additional baseUriParameters in different position", async () => {
+    const doc = getHappySpec();
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/checkout/{apiFamily}/{version}";
+    doc["baseUriParameters"]["apiFamily"] = {
+      description: "my additional parameter",
+      example: "hello"
+    };
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+    breaksOnlyOneRule(
+      result,
+      "http://a.ml/vocabularies/data#baseuriparameters-must-only-have-shortcode"
+    );
+  });
 });


### PR DESCRIPTION
baseUriParameter section *MUST* only have  shortCode rule for ramllint.

To run tests
```bash
TS_NODE_COMPILER_OPTIONS='{"rootDir":"."}' npx mocha test/mercury/baseuriparameters.test.ts
```