### PR TITLE
Add a rule to check baseUri pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The default profile validates the following rules from the [Mercury API Definiti
 * `queryParameters` MUST be camelCase
 * Response codes MUST have a `description`
 * Response codes `description` MUST NOT contain the word TODO
+* `baseUri` must match the pattern - `https://{shortCode}.api.commercecloud.salesforce.com/<api-family>/<api-name>/{version}`
 
 ## Contributing
 

--- a/profiles/mercury.raml
+++ b/profiles/mercury.raml
@@ -27,6 +27,7 @@ violation:
   - require-json
   - resource-name-validation
   - version-format
+  - base-uri-matches-pattern
 
 validations:
 
@@ -159,4 +160,14 @@ validations:
         pattern: ^v[0-9]+$
         minCount: 1
 
+  base-uri-matches-pattern:
+    message: The baseUri must match the pattern - https://{shortCode}.api.commercecloud.salesforce.com/<api-family>/<api-name>/{version}
+    targetClass: apiContract.WebAPI
+    functionConstraint:
+      code: |
+        function(resource) {
+          const baseUriRegex = /^https:\/\/{shortCode}.api.commercecloud.salesforce.com\/[a-z]+-?[a-z]+\/[a-z]+-?[a-z]+\/{version}$/;
+          const server = resource['apiContract:server'];
+          return server ? baseUriRegex.test(server[0]['core:urlTemplate'][0]) : false;
+        }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2019, salesforce.com, inc.
+ * Copyright (c) 2020, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import path from "path";
-import amf, { Raml10Parser } from "amf-client-js";
+import amf from "amf-client-js";
 import { FatRamlResourceLoader } from "./exchange-connector";
 
 function validateCustom(

--- a/test/mercury.raml
+++ b/test/mercury.raml
@@ -4,6 +4,7 @@ title: Test Raml File
 version: v1
 mediaType: application/json
 protocols: https
+baseUri: https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}
 description: This is a description of the API spec
 
 types:

--- a/test/mercury/base-uri-pattern.test.ts
+++ b/test/mercury/base-uri-pattern.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable no-undef */
+"use strict";
+import {
+  getHappySpec,
+  renderSpecAsFile,
+  breaksOnlyOneRule
+} from "../utils.test";
+import { validateFile } from "../../src/validator";
+
+const PROFILE = "mercury";
+const RULE = "http://a.ml/vocabularies/data#base-uri-matches-pattern";
+
+describe("base uri pattern validation", () => {
+  let doc;
+
+  beforeEach(() => {
+    doc = getHappySpec();
+  });
+
+  it("should not conform if the baseUri is missing", async () => {
+    delete doc.baseUri;
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the protocol is http", async () => {
+    doc["baseUri"] =
+      "http://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the protocol is missing", async () => {
+    doc["baseUri"] =
+      "{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the shortCode is not followed by 'api.commercecloud.salesforce.com'", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.salesforce.commercecloud.com/test-family/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api family is camelCase", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/testFamily/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api family is PascalCase", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/TestFamily/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api family is snake_case", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test_family/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+  
+  it("should not conform if the api name is camelCase", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/testApi/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api name is PascalCase", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/TestApi/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api name is snake_case", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test_api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if shortCode is missing ", async () => {
+    doc["baseUri"] =
+      "https://api.commercecloud.salesforce.com/test-family/testApi/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api family or the api name is missing", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-api/{version}";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the version is missing", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the baseUri doesn't end with {version}", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}/";
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+});

--- a/test/mercury/base-uri-pattern.test.ts
+++ b/test/mercury/base-uri-pattern.test.ts
@@ -9,7 +9,8 @@
 import {
   getHappySpec,
   renderSpecAsFile,
-  breaksOnlyOneRule
+  breaksOnlyOneRule,
+  conforms
 } from "../utils.test";
 import { validateFile } from "../../src/validator";
 
@@ -23,8 +24,15 @@ describe("base uri pattern validation", () => {
     doc = getHappySpec();
   });
 
+  it("should conform if the baseUri matches the pattern", async () => {
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    conforms(result);
+  });
+
   it("should not conform if the baseUri is missing", async () => {
     delete doc.baseUri;
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -33,6 +41,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the protocol is http", async () => {
     doc["baseUri"] =
       "http://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -41,6 +50,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the protocol is missing", async () => {
     doc["baseUri"] =
       "{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -49,6 +59,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the shortCode is not followed by 'api.commercecloud.salesforce.com'", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.salesforce.commercecloud.com/test-family/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -57,6 +68,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api family is camelCase", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/testFamily/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -65,6 +77,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api family is PascalCase", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/TestFamily/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -73,6 +86,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api family is snake_case", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test_family/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -81,6 +95,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api name is camelCase", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-family/testApi/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -89,6 +104,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api name is PascalCase", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-family/TestApi/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -97,6 +113,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api name is snake_case", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test_api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -105,6 +122,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if shortCode is missing ", async () => {
     doc["baseUri"] =
       "https://api.commercecloud.salesforce.com/test-family/testApi/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -113,6 +131,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the api family or the api name is missing", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-api/{version}";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -121,6 +140,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the version is missing", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);
@@ -129,6 +149,7 @@ describe("base uri pattern validation", () => {
   it("should not conform if the baseUri doesn't end with {version}", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}/";
+
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 
     breaksOnlyOneRule(result, RULE);


### PR DESCRIPTION
There should be a base uri and it should match this pattern:
https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}