### PR TITLE
Update the base uri rule

### DIFF
--- a/profiles/mercury.raml
+++ b/profiles/mercury.raml
@@ -166,7 +166,7 @@ validations:
     functionConstraint:
       code: |
         function(resource) {
-          const baseUriRegex = /^https:\/\/{shortCode}.api.commercecloud.salesforce.com\/[a-z]+-?[a-z]+\/[a-z]+-?[a-z]+\/{version}$/;
+          const baseUriRegex = /^https:\/\/{shortCode}.api.commercecloud.salesforce.com\/([a-z]+-?)+\/([a-z]+-?)+\/{version}\/?$/;
           const server = resource['apiContract:server'];
           return server ? baseUriRegex.test(server[0]['core:urlTemplate'][0]) : false;
         }

--- a/profiles/mercury.raml
+++ b/profiles/mercury.raml
@@ -167,7 +167,19 @@ validations:
       code: |
         function(resource) {
           const baseUriRegex = /^https:\/\/{shortCode}.api.commercecloud.salesforce.com\/([a-z]+-?)+\/([a-z]+-?)+\/{version}\/?$/;
-          const server = resource['apiContract:server'];
-          return server ? baseUriRegex.test(server[0]['core:urlTemplate'][0]) : false;
+          const servers = resource['apiContract:server'];
+          if(servers.length < 1) {
+            return false;
+          }
+          let result = true;
+          servers.forEach(server => {
+            urlTemplates = server['core:urlTemplate'];
+            urlTemplates.forEach(urlTemplate => {
+              if(!baseUriRegex.test(urlTemplate)) {
+                result = false;
+              }
+            });
+          });
+          return result;
         }
 

--- a/profiles/mercury.raml
+++ b/profiles/mercury.raml
@@ -166,7 +166,7 @@ validations:
     functionConstraint:
       code: |
         function(resource) {
-          const baseUriRegex = /^https:\/\/{shortCode}.api.commercecloud.salesforce.com\/([a-z]+-?)+\/([a-z]+-?)+\/{version}\/?$/;
+          const baseUriRegex = /^https:\/\/{shortCode}\.api\.commercecloud\.salesforce\.com\/([a-z]([a-z0-9-])*[a-z0-9]+)\/([a-z]([a-z0-9-])*[a-z0-9]+)\/{version}\/?$/;
           const servers = resource['apiContract:server'];
           if(servers.length < 1) {
             return false;

--- a/test/mercury/base-uri-pattern.test.ts
+++ b/test/mercury/base-uri-pattern.test.ts
@@ -65,6 +65,51 @@ describe("base uri pattern validation", () => {
     breaksOnlyOneRule(result, RULE);
   });
 
+  it("should conform if the api family has more than 2 words ", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-api-family-name/test-api/{version}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    conforms(result);
+  });
+
+  it("should conform if the api name has more than 2 words ", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-dummy-api-name/{version}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    conforms(result);
+  });
+
+  it("should not conform if the api family is preceded by 2 forward-slashes", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com//test-family/test-api/{version}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the api name is preceded by 2 forward-slashes", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family//test-api/{version}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the version is preceded by 2 forward-slashes", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api//{version}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
   it("should not conform if the api family is camelCase", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/testFamily/test-api/{version}";
@@ -146,9 +191,27 @@ describe("base uri pattern validation", () => {
     breaksOnlyOneRule(result, RULE);
   });
 
-  it("should not conform if the baseUri doesn't end with {version}", async () => {
+  it("should conform if the baseUri ends with a forward-slash", async () => {
     doc["baseUri"] =
       "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{version}/";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    conforms(result);
+  });
+
+  it("should not conform if the shortCode is uppercase", async () => {
+    doc["baseUri"] =
+      "https://{SHORTCODE}.api.commercecloud.salesforce.com/test-family/test-api/{version}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
+
+  it("should not conform if the version is uppercase", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud.salesforce.com/test-family/test-api/{VERSION}";
 
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
 

--- a/test/mercury/base-uri-pattern.test.ts
+++ b/test/mercury/base-uri-pattern.test.ts
@@ -217,4 +217,13 @@ describe("base uri pattern validation", () => {
 
     breaksOnlyOneRule(result, RULE);
   });
+
+  it("should not conform if there is a comma", async () => {
+    doc["baseUri"] =
+      "https://{shortCode}.api.commercecloud,salesforce.com/test-family/test-api/{VERSION}";
+
+    const result = await validateFile(renderSpecAsFile(doc), PROFILE);
+
+    breaksOnlyOneRule(result, RULE);
+  });
 });


### PR DESCRIPTION
* Allow a forward slash at the end of the base uri
* Fix the regex so that the rule doesn't fail if the api family and the api name have more than two words
* Add more tests