### PR TITLE
Create release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ jobs:
       name: node/default
       tag: '10.16'
     steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm ci
       - run:
           name: Create npmrc file to authenticate with npm registry.
           command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ workflows:
             tags:
               ignore: /^v.*/
   build-test-and-deploy:
+    jobs:
       - build:
           filters:
             tags:
@@ -54,7 +55,6 @@ workflows:
           requires:
             - confirm-publish-if-tagged
           
-  
 orbs:
   node: circleci/node@1.1
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,11 @@ workflows:
               ignore: /^v.*/
   build-test-and-deploy:
       - build:
-        filters:
-          tags:
-            only: /^v.*/
-          branches:
-            ignore: /.*/
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - confirm-publish-if-tagged:
           filters:
             tags:
@@ -45,6 +45,16 @@ workflows:
           type: approval
           requires:
             - build
+      - publish:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          requires:
+            - confirm-publish-if-tagged
+          
+  
 orbs:
   node: circleci/node@1.1
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,40 @@ jobs:
       - run: npm run test
       - store_test_results:
           path: reports
+  publish:
+    executor:
+      name: node/default
+      tag: '10.16'
+    steps:
+      - run:
+          name: Create npmrc file to authenticate with npm registry.
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+      - run: npm publish
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-      - build
-
+      - build:
+          filters:
+            tags:
+              ignore: /^v.*/
+  build-test-and-deploy:
+      - build:
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+      - confirm-publish-if-tagged:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          type: approval
+          requires:
+            - build
 orbs:
   node: circleci/node@1.1
 version: 2.1
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### 0.3.2
+* Now uses AMF 4.0!
+* Fixed an issue where some transitive dependencies weren't resolved properly
+* `baseUri` must now match the pattern - `https://{shortCode}.api.commercecloud.salesforce.com/<api-family>/<api-name>/{version}`
+
 ### 0.3.1
 * Dependency issue fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "",
   "files": [
     "/bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "files": [
     "/bin",


### PR DESCRIPTION

* Now uses AMF 4.0!
* Fixed an issue where some transitive dependencies weren't resolved properly
* `baseUri` must now match the pattern - `https://{shortCode}.api.commercecloud.salesforce.com/<api-family>/<api-name>/{version}`