### PR TITLE
Provide error message when profile fails to parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8602,6 +8602,15 @@
       "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
       "dev": true
     },
+    "webapi-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
+      "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
+      "dev": true,
+      "requires": {
+        "ajv": "6.5.2"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2312,9 +2312,9 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-match-patch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
-      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "prepack": "npm run clean && npm run compile && oclif-dev manifest && oclif-dev readme",
     "pretest": "npm run depcheck && npm run lint",
     "lint": "eslint \"**/*.ts\" --quiet --fix",
-    "test:debug": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc mocha \"test/**/*.test.ts\" --grep \"#validateCustom\"",
+    "test:debug": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc mocha \"test/**/*.test.ts\"",
     "test": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc mocha \"test/**/*.test.ts\" --reporter=xunit --reporter-options output=reports/generator.xml",
     "version": "oclif-dev readme && git add README.md",
     "snyk-protect": "snyk protect",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "prepack": "npm run clean && npm run compile && oclif-dev manifest && oclif-dev readme",
     "pretest": "npm run depcheck && npm run lint",
     "lint": "eslint \"**/*.ts\" --quiet --fix",
-    "test:debug": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc mocha \"test/**/*.test.ts\"",
+    "test:debug": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc mocha \"test/**/*.test.ts\" --grep \"#validateCustom\"",
     "test": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' nyc mocha \"test/**/*.test.ts\" --reporter=xunit --reporter-options output=reports/generator.xml",
     "version": "oclif-dev readme && git add README.md",
     "snyk-protect": "snyk protect",
@@ -149,7 +149,8 @@
     "nyc": "^15.0.0",
     "prettier": "^1.15.2",
     "sinon": "^9.0.2",
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "webapi-parser": "^0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,7 +19,6 @@ export async function validateCustom(
     // We rethrow to provide a cleaner error message
     throw new Error(err.vw);
   }
-  console.log("SHOULD NOT HIT");
   const report = await amf.Core.validate(
     model,
     profileName,

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -13,8 +13,14 @@ function validateCustom(
   profileFile: string
 ): Promise<amf.client.validate.ValidationReport> {
   return new Promise(async resolve => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const profileName: any = await amf.Core.loadValidationProfile(profileFile);
+    let profileName: amf.ProfileName;
+    try {
+      profileName = await amf.Core.loadValidationProfile(profileFile);
+    } catch (err) {
+      console.error("Error parsing validation profile.");
+      console.error(err.vw);
+      process.exit(1);
+    }
     const report = await amf.Core.validate(
       model,
       profileName,

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -8,26 +8,24 @@ import path from "path";
 import amf from "amf-client-js";
 import { FatRamlResourceLoader } from "./exchange-connector";
 
-function validateCustom(
+export async function validateCustom(
   model: amf.model.document.BaseUnit,
   profileFile: string
 ): Promise<amf.client.validate.ValidationReport> {
-  return new Promise(async resolve => {
-    let profileName: amf.ProfileName;
-    try {
-      profileName = await amf.Core.loadValidationProfile(profileFile);
-    } catch (err) {
-      console.error("Error parsing validation profile.");
-      console.error(err.vw);
-      process.exit(1);
-    }
-    const report = await amf.Core.validate(
-      model,
-      profileName,
-      amf.MessageStyles.RAML
-    );
-    resolve(report);
-  });
+  let profileName: amf.ProfileName;
+  try {
+    profileName = await amf.Core.loadValidationProfile(profileFile);
+  } catch (err) {
+    // We rethrow to provide a cleaner error message
+    throw new Error(err.vw);
+  }
+  console.log("SHOULD NOT HIT");
+  const report = await amf.Core.validate(
+    model,
+    profileName,
+    amf.MessageStyles.RAML
+  );
+  return report;
 }
 
 export async function validateModel(

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -9,7 +9,8 @@
 import { expect, default as chai } from "chai";
 import sinon from "sinon";
 import chaiAsPromised from "chai-as-promised";
-import { printResults, validateFile } from "../src/validator";
+import * as wap from "webapi-parser";
+import { printResults, validateFile, validateCustom } from "../src/validator";
 import {
   getHappySpec,
   renderSpecAsFile,
@@ -66,5 +67,23 @@ describe("#printResults", () => {
     return expect(consoleSpy.getCall(0).args[0]).to.have.string(
       "Level: Warning"
     );
+  });
+});
+
+describe("#validateCustom", () => {
+  let model: wap.model.document.BaseUnit;
+
+  before(() => {
+    wap.WebApiParser.init();
+  });
+
+  beforeEach(() => {
+    model = new wap.webapi.WebApiDocument();
+  });
+
+  it("missing validation profile", () => {
+    expect(
+      validateCustom(model, "file://MISSINGFILE")
+    ).to.be.eventually.rejectedWith("No registered runtime validator");
   });
 });


### PR DESCRIPTION
Need to write a test for this, but basically someone writing profiles without this they would always get the following error regardless.

```
➜  raml-toolkit git:(master) ✗ ./bin/run -p aip test/mercury.raml 
(node:84603) UnhandledPromiseRejectionWarning
(node:84603) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:84603) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

The error now looks like
```
➜  raml-toolkit git:(master) ✗ ./bin/run -p aip test/mercury.raml
Error parsing validation profile.
  Message: Syntax error in the following text: ' JSON SHOULD be used as the representation type (TODO: dupe/conflict?)'
  Target: 
Property: 
  Position: Some(LexicalInformation([(45,12)-(45,82)]))
 at location: Some(file:///Users/jalbert/src/raml-toolkit/profiles/aip.raml)
```