### PR TITLE
Avoid using intersection types and fix wrong types.

### DIFF
--- a/src/diffTool/rulesProcessor.ts
+++ b/src/diffTool/rulesProcessor.ts
@@ -82,7 +82,7 @@ async function successHandler(
   almanac: Almanac,
   ruleResult: RuleResult
 ): Promise<void> {
-  const nodeDiff = (await almanac.factValue(DIFF_FACT_ID)) as NodeDiff;
+  const nodeDiff: NodeDiff = await almanac.factValue(DIFF_FACT_ID);
   ramlToolLogger.debug(
     `Rule '${ruleResult.name}' is passed on difference '${nodeDiff.id}'`
   );

--- a/src/exchange-connector/exchangeDirectoryParser.ts
+++ b/src/exchange-connector/exchangeDirectoryParser.ts
@@ -26,7 +26,7 @@ export function extractFiles(
   directory: string,
   removeFiles = true
 ): Promise<void[]> {
-  const files: fs.Dirent[] = getFiles(directory);
+  const files = getFiles(directory);
   const promises: Promise<void>[] = [];
   files
     .filter(file => file.isFile() && path.extname(file.name) === ".zip")

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -101,7 +101,7 @@ export function getAllDataTypes(
   api: model.document.BaseUnitWithDeclaresModel
 ): model.domain.CustomDomainProperty[] {
   let ret: model.domain.CustomDomainProperty[] = [];
-  const dataTypes: Set<string> = new Set();
+  const dataTypes = new Set<string>();
   const temp: model.domain.CustomDomainProperty[] = getDataTypesFromDeclare(
     api.declares,
     dataTypes
@@ -161,6 +161,6 @@ export function getNormalizedName(name: string): string {
 export function getApiName(
   apiModel: model.document.BaseUnitWithEncodesModel
 ): string {
-  const apiName: string = (apiModel.encodes as model.domain.WebApi).name.value();
+  const apiName = (apiModel.encodes as model.domain.WebApi).name.value();
   return getNormalizedName(apiName);
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,7 +21,7 @@ import { FatRamlResourceLoader } from "./exchange-connector";
  */
 export async function parseRamlFile(
   filename: string
-): Promise<amf.model.document.BaseUnit> {
+): Promise<model.document.Document> {
   const fileUri = `file://${path.resolve(filename)}`;
 
   // We initialize AMF first
@@ -39,7 +39,7 @@ export async function parseRamlFile(
   );
   const parser = new amf.Raml10Parser(ccEnvironment);
 
-  return parser.parseFileAsync(fileUri);
+  return parser.parseFileAsync(fileUri) as Promise<model.document.Document>;
 }
 
 function getDataTypesFromDeclare(
@@ -75,6 +75,7 @@ export function getReferenceDataTypes(
     return;
   }
   apiReferences.forEach(
+    // reference could actually be BaseUnit or BaseUnitWithDeclaresModel
     (reference: model.document.BaseUnitWithDeclaresModel) => {
       if (reference.declares) {
         dataTypes.push(
@@ -124,7 +125,7 @@ export function getAllDataTypes(
 export function resolveApiModel(
   apiModel: model.document.BaseUnit,
   resolutionPipeline: "default" | "editing" | "compatibility"
-): model.document.BaseUnit {
+): model.document.Document {
   /**
    * TODO: core.resolution.pipelines.ResolutionPipeline has all the pipelines defined but is throwing an error when used - "Cannot read property 'pipelines' of undefined".
    *  When this is fixed we should change the type of input param "resolutionPipeline"
@@ -136,7 +137,10 @@ export function resolveApiModel(
     throw new Error("Invalid resolution pipeline provided to resolve");
   }
   const resolver = new Raml10Resolver();
-  return resolver.resolve(apiModel, resolutionPipeline);
+  return resolver.resolve(
+    apiModel,
+    resolutionPipeline
+  ) as model.document.Document;
 }
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -75,7 +75,7 @@ export function getReferenceDataTypes(
     return;
   }
   apiReferences.forEach(
-    (reference: model.document.BaseUnit & model.document.DeclaresModel) => {
+    (reference: model.document.BaseUnitWithDeclaresModel) => {
       if (reference.declares) {
         dataTypes.push(
           ...getDataTypesFromDeclare(reference.declares, existingDataTypes)
@@ -98,7 +98,7 @@ export function getReferenceDataTypes(
  * @returns data types from model
  */
 export function getAllDataTypes(
-  api: model.document.BaseUnit & model.document.DeclaresModel
+  api: model.document.BaseUnitWithDeclaresModel
 ): model.domain.CustomDomainProperty[] {
   let ret: model.domain.CustomDomainProperty[] = [];
   const dataTypes: Set<string> = new Set();
@@ -122,9 +122,9 @@ export function getAllDataTypes(
  * @returns AMF model after resolving with the given pipeline
  */
 export function resolveApiModel(
-  apiModel: model.document.BaseUnit & model.document.EncodesModel,
+  apiModel: model.document.BaseUnitWithEncodesModel,
   resolutionPipeline: "default" | "editing" | "compatibility"
-): model.document.BaseUnit & model.document.EncodesModel {
+): model.document.BaseUnitWithEncodesModel {
   /**
    * TODO: core.resolution.pipelines.ResolutionPipeline has all the pipelines defined but is throwing an error when used - "Cannot read property 'pipelines' of undefined".
    *  When this is fixed we should change the type of input param "resolutionPipeline"
@@ -139,7 +139,7 @@ export function resolveApiModel(
   return resolver.resolve(
     apiModel,
     resolutionPipeline
-  ) as model.document.BaseUnit & model.document.EncodesModel;
+  ) as model.document.BaseUnitWithEncodesModel;
 }
 
 /**
@@ -162,7 +162,7 @@ export function getNormalizedName(name: string): string {
  * @returns Name of the API
  */
 export function getApiName(
-  apiModel: model.document.BaseUnit & model.document.EncodesModel
+  apiModel: model.document.BaseUnitWithEncodesModel
 ): string {
   const apiName: string = (apiModel.encodes as model.domain.WebApi).name.value();
   return getNormalizedName(apiName);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -122,9 +122,9 @@ export function getAllDataTypes(
  * @returns AMF model after resolving with the given pipeline
  */
 export function resolveApiModel(
-  apiModel: model.document.BaseUnitWithEncodesModel,
+  apiModel: model.document.BaseUnit,
   resolutionPipeline: "default" | "editing" | "compatibility"
-): model.document.BaseUnitWithEncodesModel {
+): model.document.BaseUnit {
   /**
    * TODO: core.resolution.pipelines.ResolutionPipeline has all the pipelines defined but is throwing an error when used - "Cannot read property 'pipelines' of undefined".
    *  When this is fixed we should change the type of input param "resolutionPipeline"
@@ -136,10 +136,7 @@ export function resolveApiModel(
     throw new Error("Invalid resolution pipeline provided to resolve");
   }
   const resolver = new Raml10Resolver();
-  return resolver.resolve(
-    apiModel,
-    resolutionPipeline
-  ) as model.document.BaseUnitWithEncodesModel;
+  return resolver.resolve(apiModel, resolutionPipeline);
 }
 
 /**

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -37,7 +37,7 @@ export async function validateModel(
     `file://${path.join(__dirname, "..", "profiles", `${profile}.raml`)}`
   );
 
-  return results as amf.client.validate.ValidationReport;
+  return results;
 }
 
 export async function printResults(

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -80,9 +80,9 @@ describe("Test that API Name is returned in lower camelCase", () => {
   const expectedApiName = "shopperCustomers";
 
   const testGetApiName = (name: string): string => {
-    const api: model.domain.WebApi = new model.domain.WebApi();
+    const api = new model.domain.WebApi();
     api.withName(name);
-    const doc: model.document.Document = new model.document.Document();
+    const doc = new model.document.Document();
     doc.withEncodes(api);
     return getApiName(doc);
   };
@@ -133,14 +133,14 @@ describe("Test resolving API model", () => {
     ));
 
   it("throws with null resolution pipeline", () => {
-    const apiModel: model.document.Document = new model.document.Document();
+    const apiModel = new model.document.Document();
     return expect(() => resolveApiModel(apiModel, null)).to.throw(
       "Invalid resolution pipeline provided to resolve"
     );
   });
 
   it("throws with undefined resolution pipeline", () => {
-    const apiModel: model.document.Document = new model.document.Document();
+    const apiModel = new model.document.Document();
     return expect(() => resolveApiModel(apiModel, undefined)).to.throw(
       "Invalid resolution pipeline provided to resolve"
     );

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -37,9 +37,7 @@ describe("Test RAML file", () => {
 describe("Get Data types", () => {
   it("Test valid RAML file", async () => {
     const baseUnit = await parseRamlFile(validRamlFile);
-    const dataTypes = getAllDataTypes(
-      baseUnit as model.document.BaseUnitWithDeclaresModel
-    );
+    const dataTypes = getAllDataTypes(baseUnit);
     const dataTypeNames = dataTypes.map(entry => entry.name.value());
     return expect(dataTypeNames).to.deep.equal([
       "product_search_result",
@@ -58,9 +56,7 @@ describe("Get Data types", () => {
     const refModel = await parseRamlFile(validRamlFile);
     const mainModel = await parseRamlFile(validRamlFile);
     mainModel.withReferences([refModel]);
-    const dataTypes = getAllDataTypes(
-      mainModel as model.document.BaseUnitWithDeclaresModel
-    );
+    const dataTypes = getAllDataTypes(mainModel);
     const dataTypeNames = dataTypes.map(entry => entry.name.value());
     return expect(dataTypeNames).to.deep.equal([
       "product_search_result",

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -149,10 +149,7 @@ describe("Test resolving API model", () => {
 
   it("returns model with valid model and resolution pipeline", async () => {
     const testModel = await parseRamlFile(validRamlFile);
-    const resolved = resolveApiModel(
-      testModel as model.document.BaseUnitWithEncodesModel,
-      "editing"
-    );
+    const resolved = resolveApiModel(testModel, "editing");
     return expect(resolved).to.not.be.null;
   });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -11,7 +11,6 @@ import path from "path";
 import { model } from "amf-client-js";
 import { expect, default as chai } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import _ from "lodash";
 
 import {
   getAllDataTypes,
@@ -80,7 +79,7 @@ describe("Get Data types", () => {
 describe("Test that API Name is returned in lower camelCase", () => {
   const expectedApiName = "shopperCustomers";
 
-  const testGetApiName = (name: string) => {
+  const testGetApiName = (name: string): string => {
     const api: model.domain.WebApi = new model.domain.WebApi();
     api.withName(name);
     const doc: model.document.Document = new model.document.Document();

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -71,7 +71,7 @@ describe("#printResults", () => {
 });
 
 describe("#validateCustom", () => {
-  let testModel: model.document.BaseUnit;
+  let testModel: model.document.Document;
 
   beforeEach(() => {
     testModel = new model.document.Document();


### PR DESCRIPTION
1. There are existing types that serve the same purpose as the intersection types removed.
2. The param type and return type for `resolveApiModel` were unnecessarily over-specific.
3. Cleaned up linter warnings and type annotations.
4. *Changed return type of `parseRamlFile` and `resolveApiModel` to `Document` instead of `BaseUnit`* because it's more accurate and reduces need for type assertions downstream.