### PR TITLE
Redo Snyk PRs #4344485064

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -776,11 +776,10 @@
       }
     },
     "@types/agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-GRmnDTq6ajyRyT8Ybg4IVVOyYqqFIAR4Zo9L+fdMAP+IJxd0nlTV99/IelJCBF629WOj6MpE9ohLHYCmkeJqRA==",
       "requires": {
-        "@types/events": "*",
         "@types/node": "*"
       }
     },
@@ -819,7 +818,8 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "8.1.0",
@@ -5851,9 +5851,9 @@
       }
     },
     "needle": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.1.tgz",
-      "integrity": "sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -6196,18 +6196,21 @@
       }
     },
     "open": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.0.3.tgz",
-      "integrity": "sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
+      "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       },
       "dependencies": {
         "is-wsl": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
         }
       }
     },
@@ -7255,9 +7258,9 @@
       }
     },
     "snyk": {
-      "version": "1.316.1",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.316.1.tgz",
-      "integrity": "sha512-z+LWT14QoOyOsqCcWGkTNlIBpCQmv7E+kMX3r43/vZeU1F9E6Ll+KVcu1simXZixZaOb97IHHIf4rxxYGw65MA==",
+      "version": "1.316.2",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.316.2.tgz",
+      "integrity": "sha512-jbO2yUxu0kM6v8jLP1Vn64ZIeznFBBfujaurKYtXUR0mnRzr64V5kEuNeCIjAp9qlSM0RjuEqOCH7eAlFTxOHw==",
       "requires": {
         "@snyk/cli-interface": "2.6.0",
         "@snyk/configstore": "^3.2.0-rc1",
@@ -7834,9 +7837,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,16 +293,49 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.20",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.20.tgz",
-      "integrity": "sha512-lzst5RU/STfoutJJv4TLE/cm1WtW3xy6Aqvqy3r1lPsGdNifgbEq4dCOYyc/ZEuhV/IStQLDFTnAlqTdolkz1Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.6.0.tgz",
+      "integrity": "sha512-jHLlsi8WzCNTlbSWFBkpNkYdhg7tOV7aV4Kfig+2hbFxuwgf8HTRVzVKBLDmhySWdbzjg1Z7yOpne8rU4hVc8g==",
       "requires": {
-        "@oclif/config": "^1",
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.2.2",
         "@oclif/parser": "^3.8.3",
-        "@oclif/plugin-help": "^2",
+        "@oclif/plugin-help": "^3",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "@oclif/plugin-help": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.0.1.tgz",
+          "integrity": "sha512-Q1OITeUBkkydPf6r5qX75KgE9capr1mNrfHtfD7gkVXmqoTndrbc++z4KfAYNf5nhTCY7N9l52sjbF6BrSGu9w==",
+          "requires": {
+            "@oclif/command": "^1.5.20",
+            "@oclif/config": "^1.15.1",
+            "chalk": "^2.4.1",
+            "indent-string": "^4.0.0",
+            "lodash.template": "^4.4.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0",
+            "widest-line": "^2.0.1",
+            "wrap-ansi": "^4.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
       }
     },
     "@oclif/config": {
@@ -392,6 +425,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.3.tgz",
       "integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
+      "dev": true,
       "requires": {
         "@oclif/command": "^1.5.13",
         "chalk": "^2.4.1",
@@ -406,12 +440,14 @@
         "indent-string": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "BSD 3-Clause",
   "dependencies": {
-    "@oclif/command": "^1.5.20",
+    "@oclif/command": "^1.6.0",
     "@oclif/config": "^1.15.1",
     "lodash": "^4.17.15",
     "amf-client-js": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,13 @@
     "typescript": "^3.7.5",
     "unzipper": "^0.10.11",
     "loglevel": "^1.6.8",
+<<<<<<< HEAD
     "snyk": "^1.316.1",
     "jsondiffpatch": "^0.4.1",
     "json-rules-engine": "^5.0.3"
+=======
+    "snyk": "^1.316.2"
+>>>>>>> origin/snyk-upgrade-a315437da81873264d8307bbef4efc5f
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
Snyk cannot sign PRs, so this PR replaces:
* #43: [Snyk] Upgrade @oclif/command from 1.5.20 to 1.6.0
* #44: [Snyk] Upgrade snyk from 1.316.1 to 1.316.2
* #48: [Snyk] Upgrade amf-client-js from 4.1.0 to 4.1.1
* #50: [Snyk] Upgrade typescript from 3.8.3 to 3.9.2
* #64: [Snyk] Upgrade js-yaml from 3.13.1 to 3.14.0

and it runs `npm audit fix`.