### PR TITLE
Fix invalid types

### DIFF
--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -206,7 +206,7 @@ describe("getSpecificApi", () => {
       null
     );
 
-    return expect(restApi).to.be.null;
+    return expect(restApi).to.eventually.be.null;
   });
 
   it("should return null it fails to fetch the asset", async () => {

--- a/src/download/exchangeDownloader.ts
+++ b/src/download/exchangeDownloader.ts
@@ -7,7 +7,6 @@
 // import "cross-fetch/polyfill";
 
 import { writeFileSync, ensureDirSync } from "fs-extra";
-import { clone } from "lodash";
 import fetch, { Response } from "node-fetch";
 import path from "path";
 
@@ -65,7 +64,17 @@ function mapCategories(categories: RawCategories[]): Categories {
 
 function getFileByClassifier(files: FileInfo[], classifier: string): FileInfo {
   const found = files.find(file => file.classifier === classifier);
-  return clone(found);
+  // There are extra properties we don't want (downloadURL, isGenerated), so we
+  // create a new object that excludes them
+  return {
+    classifier: found.classifier,
+    packaging: found.packaging,
+    externalLink: found.externalLink,
+    createdDate: found.createdDate,
+    md5: found.md5,
+    sha1: found.sha1,
+    mainFile: found.mainFile
+  };
 }
 
 function convertResponseToRestApi(apiResponse: RawRestApi): RestApi {

--- a/src/download/exchangeTypes.ts
+++ b/src/download/exchangeTypes.ts
@@ -30,3 +30,17 @@ export type FileInfo = {
 export type Categories = {
   [key: string]: string[];
 };
+
+export type RawCategories = {
+  key: string;
+  value: string[];
+};
+
+export type RawRestApi = Omit<RestApi, "categories" | "fatRaml"> & {
+  categories: RawCategories[];
+  files: FileInfo[];
+  instances: {
+    environmentName: string;
+    version: string;
+  }[];
+};


### PR DESCRIPTION
I noticed that this file used `JSON` as a type in a few places. That is not a valid type, it refers to the global JSON stringify/parse object. So I fixed that and a few other inaccurate type annotations. I also cleaned up a few of the functions.

I made one important change. `getSpecificApi` previously returned a Promise or null. I changed it always return a Promise (that could resolve to null), because having a mixed return type can add unnecessary complexity to the code that calls it. This change is technically a breaking change, because the function is a top-level export of the package. However, my next PR will be migrating code from commerce-sdk to here, so it will no longer need to be exported.