### PR TITLE
npm audit fixes for third party dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,7 +351,7 @@
     },
     "@oclif/dev-cli": {
       "version": "1.22.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.22.2.tgz",
       "integrity": "sha512-c7633R37RxrQIpwqPKxjNRm6/jb1yuG8fd16hmNz9Nw+/MUhEtQtKHSCe9ScH8n5M06l6LEo4ldk9LEGtpaWwA==",
       "dev": true,
       "requires": {
@@ -464,7 +464,7 @@
     },
     "@oclif/test": {
       "version": "1.2.5",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@oclif/test/-/test-1.2.5.tgz",
       "integrity": "sha512-8Y+Ix4A3Zhm87aL0ldVonDK7vFWyLfnFHzP3goYaLyIeh/60KL37lMxfmbp/kBN6/Y0Ru17iR1pdDi/hTDClLQ==",
       "dev": true,
       "requires": {
@@ -777,7 +777,7 @@
     },
     "@types/chai-as-promised": {
       "version": "7.1.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
       "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
       "dev": true,
       "requires": {
@@ -818,7 +818,7 @@
     },
     "@types/fs-extra": {
       "version": "8.1.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
       "dev": true,
       "requires": {
@@ -854,7 +854,7 @@
     },
     "@types/jszip": {
       "version": "3.1.7",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.1.7.tgz",
       "integrity": "sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==",
       "dev": true,
       "requires": {
@@ -886,7 +886,7 @@
     },
     "@types/node-fetch": {
       "version": "2.5.5",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
       "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
       "dev": true,
       "requires": {
@@ -916,7 +916,7 @@
     },
     "@types/tmp": {
       "version": "0.1.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
       "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
       "dev": true
     },
@@ -930,7 +930,7 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.27.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
       "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
       "dev": true,
       "requires": {
@@ -954,7 +954,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "2.27.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
       "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
       "dev": true,
       "requires": {
@@ -1684,7 +1684,7 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
@@ -1698,7 +1698,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
@@ -2453,7 +2453,7 @@
     },
     "depcheck": {
       "version": "0.9.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.9.2.tgz",
       "integrity": "sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==",
       "dev": true,
       "requires": {
@@ -2715,7 +2715,7 @@
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -2848,7 +2848,7 @@
     },
     "eslint-config-oclif": {
       "version": "3.1.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-config-oclif/-/eslint-config-oclif-3.1.0.tgz",
       "integrity": "sha512-Tqgy43cNXsSdhTLWW4RuDYGFhV240sC4ISSv/ZiUEg/zFxExSEUpRE6J+AGnkKY9dYwIW4C9b2YSUVv8z/miMA==",
       "dev": true,
       "requires": {
@@ -2860,7 +2860,7 @@
     },
     "eslint-config-prettier": {
       "version": "6.10.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
       "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
@@ -2869,7 +2869,7 @@
     },
     "eslint-config-xo": {
       "version": "0.27.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.27.2.tgz",
       "integrity": "sha512-qEuZP0zNQkWpOdNZvWnfY2GNp1AZ33uXgeOXl4DN5YVLHFvekHbeSM2FFZ8A489fp1rCCColVRlJsYMf28o4DA==",
       "dev": true
     },
@@ -2892,7 +2892,7 @@
     },
     "eslint-config-xo-typescript": {
       "version": "0.19.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.19.0.tgz",
       "integrity": "sha512-+SDt/rT2Q4Vnv4GMzgXhczikzaKMrU4EuqHxDGxdMe/ff5EAAihrkAbdg0cuSMOTLSVtkeYYMe/HLxqW815Mpg==",
       "dev": true
     },
@@ -2925,7 +2925,7 @@
     },
     "eslint-plugin-header": {
       "version": "3.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
       "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==",
       "dev": true
     },
@@ -2971,7 +2971,7 @@
     },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
       "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
@@ -4935,7 +4935,7 @@
     },
     "lint-staged": {
       "version": "8.2.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.1.tgz",
       "integrity": "sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==",
       "dev": true,
       "requires": {
@@ -5309,9 +5309,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -5651,7 +5651,7 @@
     },
     "mocha": {
       "version": "7.1.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
       "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
       "dev": true,
       "requires": {
@@ -6058,7 +6058,7 @@
     },
     "nock": {
       "version": "12.0.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
       "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
       "dev": true,
       "requires": {
@@ -6159,7 +6159,7 @@
     },
     "nyc": {
       "version": "15.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.1.tgz",
       "integrity": "sha512-n0MBXYBYRqa67IVt62qW1r/d9UH/Qtr7SF1w/nQLJ9KxvWF6b2xCHImRAixHN9tnMMYHC2P14uo6KddNGwMgGg==",
       "dev": true,
       "requires": {
@@ -7173,7 +7173,7 @@
     },
     "sinon": {
       "version": "9.0.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
       "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "js-yaml": "^3.14.0",
     "json-rules-engine": "^5.0.3",
     "jsondiffpatch": "^0.4.1",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "loglevel": "^1.6.8",
     "node-fetch": "^2.6.0",
     "snyk": "^1.341.1",


### PR DESCRIPTION
This PR contains the npm audit fixes for snyk alerts

Tested the updates by

- change to raml-toolkit dir
- npm pack
- npx commerce-apps-raml-toolkit-0.4.1.tgz ../commerce-sdk/apis/shopper-search/shopper-search.raml -p mercury