### PR TITLE
Release/20200724

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # CHANGELOG
 
+## 0.4.4
+
+* Added flag to `diff` command that adds the ability to find the difference between directories.
+
+### New Usage
+
+For complete documentation of the `diff` command, see the [README](README.md#raml-toolkit-diff-base-new).
+
+```txt
+NEW USAGE
+  $ raml-toolkit diff --dir BASE NEW
+
+ARGUMENTS
+  BASE  The base API configuration file
+  NEW   The new API configuration file
+
+OPTIONS
+  -o, --out-file=out-file  File to store the computed difference
+
+DESCRIPTION
+  This command has three modes: ruleset, diff-only, and directory.
+     Directory mode compares all the files in two directories and determines if there are any differences.
+
+  In directory mode, the arguments must be API configuration (JSON) files.
+
+  Exit statuses:
+     0 - No differences found
+     1 - Differences found
+     2 - Evaluation could not be completed
+```
+
 ## 0.4.3
 
 * Added `diff` and `download` commands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "test": "npm run test:unit && npm run test:resources",
     "test:debug": "mocha \"src/**/*.test.ts\"",
     "test:resources": "mocha \"resources/**/*.test.ts\"",
-    "test:unit": "nyc mocha \"src/**/*.test.ts\" -- --reporter=xunit --reporter-options output=reports/generator.xml",
-    "version": "oclif-dev readme && git add README.md"
+    "test:unit": "nyc mocha \"src/**/*.test.ts\" -- --reporter=xunit --reporter-options output=reports/generator.xml"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "keywords": [
     "oclif",


### PR DESCRIPTION
**NOTE:** This PR also includes the deletion of the `version` script, because we don't want to automatically commit the results of `oclif-dev readme`. The output of the command requires manual changes (primarily, the headers are the wrong level). It also depends on the compiled code, so if that is missing or outdated, the generated output will be wrong.

## 0.4.4

* Added flag to `diff` command that adds the ability to find the difference between directories.

### New Usage

For complete documentation of the `diff` command, see the [README](README.md#raml-toolkit-diff-base-new).

```txt
NEW USAGE
  $ raml-toolkit diff --dir BASE NEW

ARGUMENTS
  BASE  The base API configuration file
  NEW   The new API configuration file

OPTIONS
  -o, --out-file=out-file  File to store the computed difference

DESCRIPTION
  This command has three modes: ruleset, diff-only, and directory.
     Directory mode compares all the files in two directories and determines if there are any differences.

  In directory mode, the arguments must be API configuration (JSON) files.

  Exit statuses:
     0 - No differences found
     1 - Differences found
     2 - Evaluation could not be completed
```