### PR TITLE
New Ignore rule for difftool to ignore the changes in RAML examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "/resources"
   ],
   "scripts": {
-    "clean": "rm -rf lib",
     "build": "npm run compile",
+    "clean": "rm -rf lib",
     "compile": "tsc -b && echo Compiled",
+    "cover:unit": "nyc npm run test:unit",
+    "cover:unit:ci": "nyc npm run test:unit:ci",
     "depcheck": "depcheck",
     "docs": "npm run clean && npm run compile && oclif-dev readme",
     "lint": "sort-package-json && eslint . --ext .ts --fix",
@@ -33,15 +35,13 @@
     "prepare": "npm run snyk-protect",
     "snyk-protect": "snyk protect",
     "pretest": "npm run lint && npm run compile && npm run depcheck",
-    "pretest:ci": "npm run lint:ci && npm run compile && npm run depcheck",
     "test": "npm run cover:unit && npm run test:resource",
+    "pretest:ci": "npm run lint:ci && npm run compile && npm run depcheck",
     "test:ci": "npm run pretest:ci && npm run cover:unit:ci && npm run test:resource:ci",
-    "test:unit": "mocha \"src/**/*.test.ts\"",
-    "test:unit:ci": "npm run test:unit -- --reporter=xunit --reporter-options output=./reports/unitTests.xml",
     "test:resource": "mocha \"resources/**/*.test.ts\"",
     "test:resource:ci": "npm run test:resource -- --reporter=xunit --reporter-options output=./reports/resourceTests.xml",
-    "cover:unit": "nyc npm run test:unit",
-    "cover:unit:ci": "nyc npm run test:unit:ci"
+    "test:unit": "mocha \"src/**/*.test.ts\"",
+    "test:unit:ci": "npm run test:unit -- --reporter=xunit --reporter-options output=./reports/unitTests.xml"
   },
   "lint-staged": {
     "*.ts": [
@@ -104,10 +104,6 @@
     "timeout": 5000
   },
   "nyc": {
-    "reporter": [
-      "lcov",
-      "text"
-    ],
     "all": true,
     "branches": 85,
     "check-coverage": true,
@@ -120,6 +116,10 @@
     ],
     "lines": 85,
     "per-file": true,
+    "reporter": [
+      "lcov",
+      "text"
+    ],
     "statements": -10
   },
   "dependencies": {

--- a/resources/diff/rules/defaultRules.json
+++ b/resources/diff/rules/defaultRules.json
@@ -164,5 +164,24 @@
         "changedProperty": "core:version"
       }
     }
+  },
+  {
+    "name": "Rule to ignore changes in examples",
+    "conditions": {
+      "any": [
+        {
+          "fact": "diff",
+          "path": "$.type",
+          "operator": "contains",
+          "value": "apiContract:Example"
+        }
+      ]
+    },
+    "event": {
+      "type": "example-change",
+      "params": {
+        "category": "Ignored"
+      }
+    }
   }
 ]

--- a/resources/diff/rules/defaultRules.json
+++ b/resources/diff/rules/defaultRules.json
@@ -178,7 +178,7 @@
       ]
     },
     "event": {
-      "type": "example-change",
+      "type": "example-changed",
       "params": {
         "category": "Ignored"
       }

--- a/src/diff/changes/nodeChanges.test.ts
+++ b/src/diff/changes/nodeChanges.test.ts
@@ -31,7 +31,6 @@ describe("Create an instance of NodeChanges", () => {
     expect(nodeChanges.type).to.deep.equal(["test:type"]);
     expect(nodeChanges.added).to.deep.equal({});
     expect(nodeChanges.removed).to.deep.equal({});
-    expect(nodeChanges.ignored).to.deep.equal({});
     expect(nodeChanges.categorizedChanges).to.deep.equal([]);
   });
 });

--- a/src/diff/changes/nodeChanges.test.ts
+++ b/src/diff/changes/nodeChanges.test.ts
@@ -31,6 +31,7 @@ describe("Create an instance of NodeChanges", () => {
     expect(nodeChanges.type).to.deep.equal(["test:type"]);
     expect(nodeChanges.added).to.deep.equal({});
     expect(nodeChanges.removed).to.deep.equal({});
+    expect(nodeChanges.ignored).to.deep.equal({});
     expect(nodeChanges.categorizedChanges).to.deep.equal([]);
   });
 });
@@ -61,6 +62,55 @@ describe("Check for categorized changes in a node", () => {
     const nodeChanges = buildNodeChanges();
     nodeChanges.categorizedChanges = [];
     expect(nodeChanges.hasBreakingChanges()).to.be.false;
+  });
+});
+
+describe("Check for ignored changes in a node", () => {
+  it("returns false when there are no ignored changes", async () => {
+    const nodeChanges = buildNodeChanges();
+    expect(nodeChanges.hasCategorizedChanges()).to.be.true;
+    expect(nodeChanges.hasIgnoredChanges()).to.be.false;
+    expect(nodeChanges.getIgnoredChangesCount()).to.equal(0);
+  });
+
+  it("returns true when there exists only one ignored change", async () => {
+    const nodeChanges = buildNodeChanges();
+    nodeChanges.categorizedChanges[0].category = RuleCategory.IGNORED;
+    expect(nodeChanges.hasCategorizedChanges()).to.be.true;
+    expect(nodeChanges.hasIgnoredChanges()).to.be.true;
+    expect(nodeChanges.getIgnoredChangesCount()).to.equal(1);
+  });
+
+  it("returns true when there is an ignored change and a non breaking change", async () => {
+    const nodeChanges = buildNodeChanges();
+    nodeChanges.categorizedChanges[0].category = RuleCategory.IGNORED;
+    const nonBreakingChange = new CategorizedChange(
+      "r2",
+      "non-breaking-changed",
+      RuleCategory.NON_BREAKING,
+      ["old-non-breaking", "new-non-breaking"]
+    );
+    nodeChanges.categorizedChanges.push(nonBreakingChange);
+    expect(nodeChanges.hasCategorizedChanges()).to.be.true;
+    expect(nodeChanges.hasIgnoredChanges()).to.be.true;
+    expect(nodeChanges.hasBreakingChanges()).to.be.false;
+    expect(nodeChanges.getIgnoredChangesCount()).to.equal(1);
+  });
+
+  it("returns true when there multiple ignored changes", async () => {
+    const nodeChanges = buildNodeChanges();
+    nodeChanges.categorizedChanges[0].category = RuleCategory.IGNORED;
+    const nonBreakingChange = new CategorizedChange(
+      "r2",
+      "non-breaking-changed",
+      RuleCategory.IGNORED,
+      ["old-ignored-change", "new-ignored-change"]
+    );
+    nodeChanges.categorizedChanges.push(nonBreakingChange);
+    expect(nodeChanges.hasCategorizedChanges()).to.be.true;
+    expect(nodeChanges.hasIgnoredChanges()).to.be.true;
+    expect(nodeChanges.hasBreakingChanges()).to.be.false;
+    expect(nodeChanges.getIgnoredChangesCount()).to.equal(2);
   });
 });
 

--- a/src/diff/changes/nodeChanges.test.ts
+++ b/src/diff/changes/nodeChanges.test.ts
@@ -86,7 +86,7 @@ describe("Check for ignored changes in a node", () => {
     nodeChanges.categorizedChanges[0].category = RuleCategory.IGNORED;
     const nonBreakingChange = new CategorizedChange(
       "r2",
-      "non-breaking-changed",
+      "non-breaking-change",
       RuleCategory.NON_BREAKING,
       ["old-non-breaking", "new-non-breaking"]
     );
@@ -102,7 +102,7 @@ describe("Check for ignored changes in a node", () => {
     nodeChanges.categorizedChanges[0].category = RuleCategory.IGNORED;
     const nonBreakingChange = new CategorizedChange(
       "r2",
-      "non-breaking-changed",
+      "non-breaking-change",
       RuleCategory.IGNORED,
       ["old-ignored-change", "new-ignored-change"]
     );

--- a/src/diff/changes/nodeChanges.ts
+++ b/src/diff/changes/nodeChanges.ts
@@ -14,7 +14,6 @@ import { RuleCategory } from "../ruleSet";
 export class NodeChanges {
   public added: { [key: string]: unknown };
   public removed: { [key: string]: unknown };
-  public ignored: { [key: string]: unknown };
   //categorized changes of the node
   public categorizedChanges: CategorizedChange[];
 
@@ -26,7 +25,6 @@ export class NodeChanges {
   constructor(public id: string, public type: string[]) {
     this.added = {};
     this.removed = {};
-    this.ignored = {};
     this.categorizedChanges = [];
   }
 

--- a/src/diff/changes/nodeChanges.ts
+++ b/src/diff/changes/nodeChanges.ts
@@ -14,6 +14,7 @@ import { RuleCategory } from "../ruleSet";
 export class NodeChanges {
   public added: { [key: string]: unknown };
   public removed: { [key: string]: unknown };
+  public ignored: { [key: string]: unknown };
   //categorized changes of the node
   public categorizedChanges: CategorizedChange[];
 
@@ -25,6 +26,7 @@ export class NodeChanges {
   constructor(public id: string, public type: string[]) {
     this.added = {};
     this.removed = {};
+    this.ignored = {};
     this.categorizedChanges = [];
   }
 
@@ -41,6 +43,15 @@ export class NodeChanges {
   hasBreakingChanges(): boolean {
     return this.categorizedChanges.some(
       c => c.category === RuleCategory.BREAKING
+    );
+  }
+
+  /**
+   * Returns true when there are ignored changes
+   */
+  hasIgnoredChanges(): boolean {
+    return this.categorizedChanges.some(
+      c => c.category === RuleCategory.IGNORED
     );
   }
 

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -126,7 +126,7 @@ describe("Version change", () => {
 });
 
 describe("Examples change", () => {
-  it("does not apply ignore examples rule on a change that has no apiContract:Example change type", async () => {
+  it("does not apply ignore examples rule on a change that has no apiContract:Example node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
       "apiContract:WebAPI"
     ]);
@@ -140,7 +140,7 @@ describe("Examples change", () => {
     expect(changes[0].categorizedChanges[0].ruleName).to.not.equal(rule.name);
   });
 
-  it("does not apply ignore examples rule on a change that has undefined as the change type", async () => {
+  it("does not apply ignore examples rule on a change that has undefined as the node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
       undefined
     ]);
@@ -153,7 +153,7 @@ describe("Examples change", () => {
     expect(changes[0].categorizedChanges).to.be.empty;
   });
 
-  it("does not apply ignore examples rule on a change that has no change type", async () => {
+  it("does not apply ignore examples rule on a change that has no node type", async () => {
     const nodeChanges = new NodeChanges(
       "#/web-api/end-points/resource/get",
       []
@@ -168,7 +168,7 @@ describe("Examples change", () => {
     expect(changes[0].categorizedChanges).to.be.empty;
   });
 
-  it("applies ignore examples rule on a change that includes only one apiContract:Example change type", async () => {
+  it("applies ignore examples rule on a change that includes only one apiContract:Example node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
       "apiContract:Example"
     ]);
@@ -182,7 +182,7 @@ describe("Examples change", () => {
     verifyRule(changes[0], rule);
   });
 
-  it("applies ignore examples rule changes that includes many apiContract:Example change type", async () => {
+  it("applies ignore examples rule changes that includes many apiContract:Example node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
       "apiContract:Example"
     ]);

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -164,7 +164,6 @@ describe("Examples change", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-change");
     expect(changes[0].categorizedChanges).to.be.empty;
   });
 

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -136,7 +136,7 @@ describe("Examples change", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-change");
+    const rule = defaultRules.find(r => r.event.type === "example-changed");
     expect(changes[0].categorizedChanges[0].ruleName).to.not.equal(rule.name);
   });
 
@@ -177,7 +177,7 @@ describe("Examples change", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-change");
+    const rule = defaultRules.find(r => r.event.type === "example-changed");
     verifyRule(changes[0], rule);
   });
 
@@ -191,7 +191,7 @@ describe("Examples change", () => {
       [nodeChanges, nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-change");
+    const rule = defaultRules.find(r => r.event.type === "example-changed");
     verifyRule(changes[0], rule, 2);
   });
 });

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -18,7 +18,11 @@ const defaultRules = fs.readJSONSync(ApiDifferencer.DEFAULT_RULES_PATH);
  * @param nodeChanges - Node changes
  * @param rule - Rule that is expected to be applied
  */
-function verifyRule(nodeChanges: NodeChanges, rule: Rule): void {
+function verifyRule(
+  nodeChanges: NodeChanges,
+  rule: Rule,
+  countOfChanges = 1
+): void {
   const categorizedChanges = nodeChanges.categorizedChanges;
   let changedValues: [unknown, unknown];
   if (rule.event.params.changedProperty) {
@@ -27,7 +31,7 @@ function verifyRule(nodeChanges: NodeChanges, rule: Rule): void {
       nodeChanges.added[rule.event.params.changedProperty]
     ];
   }
-  expect(categorizedChanges).to.have.length(1);
+  expect(categorizedChanges).to.have.length(countOfChanges);
   expect(categorizedChanges[0].ruleName).to.equal(rule.name);
   expect(categorizedChanges[0].ruleEvent).to.equal(rule.event.type);
   expect(categorizedChanges[0].category).to.equal(rule.event.params.category);
@@ -118,5 +122,77 @@ describe("Version change", () => {
     );
     const rule = defaultRules.find(r => r.event.type === "version-changed");
     verifyRule(changes[0], rule);
+  });
+});
+
+describe("Examples change", () => {
+  it("does not apply ignore examples rule on a change that has no apiContract:Example change type", async () => {
+    const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
+      "apiContract:WebAPI"
+    ]);
+    nodeChanges.added = { "core:version": "v2" };
+    nodeChanges.removed = { "core:version": "v1" };
+    const changes = await applyRules(
+      [nodeChanges],
+      ApiDifferencer.DEFAULT_RULES_PATH
+    );
+    const rule = defaultRules.find(r => r.event.type === "example-change");
+    expect(changes[0].categorizedChanges[0].ruleName).to.not.equal(rule.name);
+  });
+
+  it("does not apply ignore examples rule on a change that has undefined as the change type", async () => {
+    const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
+      undefined
+    ]);
+    nodeChanges.added = { "core:version": "v2" };
+    nodeChanges.removed = { "core:version": "v1" };
+    const changes = await applyRules(
+      [nodeChanges],
+      ApiDifferencer.DEFAULT_RULES_PATH
+    );
+    expect(changes[0].categorizedChanges).to.be.empty;
+  });
+
+  it("does not apply ignore examples rule on a change that has no change type", async () => {
+    const nodeChanges = new NodeChanges(
+      "#/web-api/end-points/resource/get",
+      []
+    );
+    nodeChanges.added = { "core:version": "v2" };
+    nodeChanges.removed = { "core:version": "v1" };
+    const changes = await applyRules(
+      [nodeChanges],
+      ApiDifferencer.DEFAULT_RULES_PATH
+    );
+    const rule = defaultRules.find(r => r.event.type === "example-change");
+    expect(changes[0].categorizedChanges).to.be.empty;
+  });
+
+  it("applies ignore examples rule on a change that includes only one apiContract:Example change type", async () => {
+    const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
+      "apiContract:Example"
+    ]);
+    nodeChanges.added = { "core:description": "Old example" };
+    nodeChanges.removed = { "core:description": "New example" };
+    const changes = await applyRules(
+      [nodeChanges],
+      ApiDifferencer.DEFAULT_RULES_PATH
+    );
+    const rule = defaultRules.find(r => r.event.type === "example-change");
+    verifyRule(changes[0], rule);
+  });
+
+  it("applies ignore examples rule changes that includes many apiContract:Example change type", async () => {
+    const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
+      "apiContract:Example"
+    ]);
+    nodeChanges.added = { "core:description": "Old example" };
+    nodeChanges.removed = { "core:description": "New example" };
+    const changes = await applyRules(
+      [nodeChanges, nodeChanges],
+      ApiDifferencer.DEFAULT_RULES_PATH
+    );
+    const rule = defaultRules.find(r => r.event.type === "example-change");
+    verifyRule(changes[0], rule, 2);
   });
 });

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -31,7 +31,7 @@ function verifyRule(
       nodeChanges.added[rule.event.params.changedProperty]
     ];
   }
-  expect(categorizedChanges).to.have.length(countOfChanges);
+  expect(categorizedChanges).to.have.lengthOf(countOfChanges);
   expect(categorizedChanges[0].ruleName).to.equal(rule.name);
   expect(categorizedChanges[0].ruleEvent).to.equal(rule.event.type);
   expect(categorizedChanges[0].category).to.equal(rule.event.params.category);


### PR DESCRIPTION
Included changes
- New default rule to ignore example changes
- Test cases for default rule and node type structural changes
- Sorted package.json
