### PR TITLE
Upgrade prettier to 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6626,9 +6626,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "mocha": "^7.0.1",
     "nock": "^12.0.2",
     "nyc": "^15.0.0",
-    "prettier": "^1.15.2",
+    "prettier": "^2.0.5",
     "sinon": "^9.0.2",
     "sort-package-json": "^1.44.0",
     "tslib": "^1.10.0",

--- a/resources/lint/profiles/mercury.base-uri.test.ts
+++ b/resources/lint/profiles/mercury.base-uri.test.ts
@@ -10,7 +10,7 @@ import {
   renderSpecAsFile,
   breaksOnlyOneRule,
   breaksTheseRules,
-  conforms
+  conforms,
 } from "../../../testResources/testUtils";
 import { validateFile } from "../../../src/lint/lint";
 

--- a/resources/lint/profiles/mercury.camelcase-method-displayname.test.ts
+++ b/resources/lint/profiles/mercury.camelcase-method-displayname.test.ts
@@ -15,7 +15,7 @@ describe("camelcase method displayname tests", () => {
     "http://a.ml/vocabularies/data#camelcase-method-displayname";
   let doc;
 
-  beforeEach(function() {
+  beforeEach(function () {
     doc = utils.getHappySpec();
   });
 

--- a/resources/lint/profiles/mercury.camelcase-query-parameters.test.ts
+++ b/resources/lint/profiles/mercury.camelcase-query-parameters.test.ts
@@ -11,7 +11,7 @@ import {
   renameKey,
   conforms,
   breaksOnlyOneRule,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";
@@ -21,7 +21,7 @@ describe("camelcase query parameters test", () => {
   let doc;
   let parameters;
 
-  beforeEach(function() {
+  beforeEach(function () {
     doc = getHappySpec();
     parameters = doc["/resource"]["/{resourceId}"].get.queryParameters;
   });

--- a/resources/lint/profiles/mercury.camelcase-template-parameters.test.ts
+++ b/resources/lint/profiles/mercury.camelcase-template-parameters.test.ts
@@ -10,7 +10,7 @@ import {
   getHappySpec,
   breaksOnlyOneRule,
   renameKey,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";

--- a/resources/lint/profiles/mercury.mercury-profile.test.ts
+++ b/resources/lint/profiles/mercury.mercury-profile.test.ts
@@ -11,7 +11,7 @@ import {
   conforms,
   breaksOnlyOneRule,
   renameKey,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";

--- a/resources/lint/profiles/mercury.no-literal-question-marks-in-parameters.test.ts
+++ b/resources/lint/profiles/mercury.no-literal-question-marks-in-parameters.test.ts
@@ -11,7 +11,7 @@ import {
   renameKey,
   conforms,
   breaksTheseRules,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";
@@ -25,7 +25,7 @@ describe("no literal question marks in query parameters tests", () => {
   let doc;
   let parameters;
 
-  beforeEach(function() {
+  beforeEach(function () {
     doc = getHappySpec();
     parameters = doc["/resource"]["/{resourceId}"].get.queryParameters;
   });

--- a/resources/lint/profiles/mercury.no-literal-question-marks-in-property-names.test.ts
+++ b/resources/lint/profiles/mercury.no-literal-question-marks-in-property-names.test.ts
@@ -11,7 +11,7 @@ import {
   renameKey,
   conforms,
   breaksOnlyOneRule,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";
@@ -23,7 +23,7 @@ describe("no literal question marks in property name tests", () => {
   let properties;
   let datatypeProperties;
 
-  beforeEach(function() {
+  beforeEach(function () {
     doc = getHappySpec();
     properties =
       doc["/resource"]["/{resourceId}"].get.responses["200"].body[

--- a/resources/lint/profiles/mercury.profile.test.ts
+++ b/resources/lint/profiles/mercury.profile.test.ts
@@ -11,7 +11,7 @@ import {
   conforms,
   breaksOnlyOneRule,
   renameKey,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";

--- a/resources/lint/profiles/mercury.resource-validation.test.ts
+++ b/resources/lint/profiles/mercury.resource-validation.test.ts
@@ -11,7 +11,7 @@ import {
   conforms,
   breaksTheseRules,
   renameKey,
-  renderSpecAsFile
+  renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
 const PROFILE = "mercury";

--- a/resources/lint/profiles/mercury.unique-display-name.test.ts
+++ b/resources/lint/profiles/mercury.unique-display-name.test.ts
@@ -9,7 +9,7 @@ import {
   getHappySpec,
   renderSpecAsFile,
   breaksOnlyOneRule,
-  conforms
+  conforms,
 } from "../../../testResources/testUtils";
 import { validateFile } from "../../../src/lint/lint";
 

--- a/src/common/flags.test.ts
+++ b/src/common/flags.test.ts
@@ -26,7 +26,7 @@ describe("Help flag", () => {
       ...oclifFlags.help(),
       char: "h",
       description: "Show CLI help",
-      hidden: true
+      hidden: true,
     };
     stripParse(flag);
     stripParse(expected);
@@ -74,7 +74,7 @@ describe("Version flag", () => {
     const expected = {
       ...oclifFlags.version(),
       description: "Show CLI version",
-      hidden: true
+      hidden: true,
     };
     stripParse(flag);
     stripParse(expected);

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -19,7 +19,7 @@ export const logLevel = flags.build({
   // Default is manually specified because use numbers, but want to show text
   description: "[default: info] Set the level of detail in the output",
   env: "RAML_TOOLKIT_LOG_LEVEL",
-  options: Object.keys(logger.levels).map(l => l.toLowerCase()),
+  options: Object.keys(logger.levels).map((l) => l.toLowerCase()),
   parse(input: string): number {
     try {
       const int = parseInt(input, 10);
@@ -34,7 +34,7 @@ export const logLevel = flags.build({
       );
     }
     return logger.getLevel();
-  }
+  },
 });
 
 /**
@@ -49,7 +49,7 @@ export function help(
     char: "h",
     description: "Show CLI help",
     hidden: true,
-    ...options
+    ...options,
   });
 }
 
@@ -64,7 +64,7 @@ export function version(
   return flags.version({
     description: "Show CLI version",
     hidden: true,
-    ...options
+    ...options,
   });
 }
 
@@ -86,6 +86,6 @@ export function allCommonFlags(): {
   return {
     help: help(),
     "log-level": logLevel(),
-    version: version()
+    version: version(),
   };
 }

--- a/src/common/parser.test.ts
+++ b/src/common/parser.test.ts
@@ -16,7 +16,7 @@ import {
   getAllDataTypes,
   getApiName,
   parseRamlFile,
-  resolveApiModel
+  resolveApiModel,
 } from "./parser";
 
 const validRamlFile = path.join(
@@ -44,7 +44,7 @@ describe("Get Data types", () => {
   it("Test valid RAML file", async () => {
     const baseUnit = await parseRamlFile(validRamlFile);
     const dataTypes = getAllDataTypes(baseUnit);
-    const dataTypeNames = dataTypes.map(entry => entry.name.value());
+    const dataTypeNames = dataTypes.map((entry) => entry.name.value());
     return expect(dataTypeNames).to.deep.equal([
       "product_search_result",
       "ClassA",
@@ -54,7 +54,7 @@ describe("Get Data types", () => {
       "search_request",
       "password_change_request",
       "sort",
-      "result_page"
+      "result_page",
     ]);
   });
 
@@ -63,7 +63,7 @@ describe("Get Data types", () => {
     const mainModel = await parseRamlFile(validRamlFile);
     mainModel.withReferences([refModel]);
     const dataTypes = getAllDataTypes(mainModel);
-    const dataTypeNames = dataTypes.map(entry => entry.name.value());
+    const dataTypeNames = dataTypes.map((entry) => entry.name.value());
     return expect(dataTypeNames).to.deep.equal([
       "product_search_result",
       "ClassA",
@@ -73,7 +73,7 @@ describe("Get Data types", () => {
       "search_request",
       "password_change_request",
       "sort",
-      "result_page"
+      "result_page",
     ]);
   });
 });

--- a/src/common/resourceLoaders/fatRamlResourceLoader.test.ts
+++ b/src/common/resourceLoaders/fatRamlResourceLoader.test.ts
@@ -131,7 +131,7 @@ describe("Fat raml resource loader fetch tests", () => {
     fatRamlResourceLoader = new FatRamlResourceLoader("file:///workingDir");
     fatRamlResourceLoader.fsAdapter = sinon.stub({
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      readFileSync: () => {}
+      readFileSync: () => {},
     });
   });
 
@@ -148,7 +148,7 @@ describe("Fat raml resource loader fetch tests", () => {
     fatRamlResourceLoader.fsAdapter.readFileSync.returns("content");
     return fatRamlResourceLoader
       .fetch("test/exchange_modules/resource.json")
-      .then(function(s) {
+      .then(function (s) {
         sinon.assert.calledWith(
           fatRamlResourceLoader.fsAdapter.readFileSync,
           "/workingDir/exchange_modules/resource.json"
@@ -168,7 +168,7 @@ describe("Fat raml resource loader fetch tests", () => {
       .fetch(
         "first_level/exchange_modules/second_level/exchange_modules/resource.json"
       )
-      .then(function(s) {
+      .then(function (s) {
         sinon.assert.calledWith(
           fatRamlResourceLoader.fsAdapter.readFileSync,
           "/workingDir/exchange_modules/resource.json"
@@ -178,7 +178,7 @@ describe("Fat raml resource loader fetch tests", () => {
   });
 
   it("Rejected for undefined resource paths", () => {
-    return fatRamlResourceLoader.fetch(undefined).catch(function(err) {
+    return fatRamlResourceLoader.fetch(undefined).catch(function (err) {
       sinon.assert.notCalled(fatRamlResourceLoader.fsAdapter.readFileSync);
       return expect(err.toString()).to.eql(
         "amf.client.resource.ResourceNotFound: Resource cannot be found: undefined"
@@ -187,7 +187,7 @@ describe("Fat raml resource loader fetch tests", () => {
   });
 
   it("Rejected for undefined resource paths", () => {
-    return fatRamlResourceLoader.fetch(null).catch(function(err) {
+    return fatRamlResourceLoader.fetch(null).catch(function (err) {
       sinon.assert.notCalled(fatRamlResourceLoader.fsAdapter.readFileSync);
       return expect(err.toString()).to.eql(
         "amf.client.resource.ResourceNotFound: Resource cannot be found: null"
@@ -201,7 +201,7 @@ describe("Fat raml resource loader fetch tests", () => {
     );
     return fatRamlResourceLoader
       .fetch("exchange_modules/resource.json")
-      .catch(function(err) {
+      .catch(function (err) {
         sinon.assert.calledWith(
           fatRamlResourceLoader.fsAdapter.readFileSync,
           sinon.match.string
@@ -213,7 +213,7 @@ describe("Fat raml resource loader fetch tests", () => {
   });
 
   it("Rejected for resource paths not starting with 'exchange_modules/'", () => {
-    return fatRamlResourceLoader.fetch("test").catch(function(err) {
+    return fatRamlResourceLoader.fetch("test").catch(function (err) {
       sinon.assert.notCalled(fatRamlResourceLoader.fsAdapter.readFileSync);
       return expect(err.toString()).to.eql(
         "amf.client.resource.ResourceNotFound: Resource cannot be found: test"

--- a/src/diff/amfGraphDifferencer.test.ts
+++ b/src/diff/amfGraphDifferencer.test.ts
@@ -10,7 +10,7 @@ import {
   DeltaType,
   findGraphChanges,
   parseNodeDelta,
-  parsePropertyDelta
+  parsePropertyDelta,
 } from "./amfGraphDifferencer";
 import * as AmfGraphTypes from "./amfGraphTypes";
 import _ from "lodash";
@@ -23,15 +23,15 @@ function buildValidGraph(): AmfGraphTypes.FlattenedGraph {
       {
         [AmfGraphTypes.KEY_NODE_ID]: "#/web-api",
         [AmfGraphTypes.KEY_NODE_TYPE]: ["apiContract:WebAPI"],
-        "core:name": "Test Raml"
+        "core:name": "Test Raml",
       },
       {
         [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource",
         [AmfGraphTypes.KEY_NODE_TYPE]: ["apiContract:endpoint"],
-        "apiContract:path": "/resource"
-      }
+        "apiContract:path": "/resource",
+      },
     ],
-    [AmfGraphTypes.KEY_CONTEXT]: { "@base": "test.raml" }
+    [AmfGraphTypes.KEY_CONTEXT]: { "@base": "test.raml" },
   };
 }
 
@@ -128,8 +128,8 @@ describe("Changes to graph nodes", () => {
         [
           {
             [AmfGraphTypes.KEY_NODE_ID]: "node1",
-            [AmfGraphTypes.KEY_NODE_TYPE]: ["test:type"]
-          }
+            [AmfGraphTypes.KEY_NODE_TYPE]: ["test:type"],
+          },
         ],
         DeltaType.MODIFIED
       )
@@ -228,40 +228,40 @@ describe("Changes to the array properties with in a node", () => {
   it("returns added array properties", async () => {
     const baseGraph = buildValidGraph();
     const arrayValue = {
-      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource"
+      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource",
     };
     baseGraph[AmfGraphTypes.KEY_GRAPH][0]["apiContract:endpoint"] = [
-      arrayValue
+      arrayValue,
     ];
 
     const newGraph = buildValidGraph();
     const newArrayValue = {
-      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource/{resourceId}"
+      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource/{resourceId}",
     };
     newGraph[AmfGraphTypes.KEY_GRAPH][0]["apiContract:endpoint"] = [
       arrayValue,
-      newArrayValue
+      newArrayValue,
     ];
 
     const nodeChanges = findGraphChanges(baseGraph, newGraph);
 
     expect(nodeChanges).to.have.lengthOf(1);
     expect(nodeChanges[0].added["apiContract:endpoint"]).to.deep.equal([
-      newArrayValue
+      newArrayValue,
     ]);
   });
 
   it("returns removed array properties", async () => {
     const baseGraph = buildValidGraph();
     const arrayValue = {
-      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource"
+      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource",
     };
     const removedArrayValue = {
-      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource/{resourceId}"
+      [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource/{resourceId}",
     };
     baseGraph[AmfGraphTypes.KEY_GRAPH][0]["apiContract:endpoint"] = [
       arrayValue,
-      removedArrayValue
+      removedArrayValue,
     ];
 
     const newGraph = buildValidGraph();
@@ -271,7 +271,7 @@ describe("Changes to the array properties with in a node", () => {
 
     expect(nodeChanges).to.have.lengthOf(1);
     expect(nodeChanges[0].removed["apiContract:endpoint"]).to.deep.equal([
-      removedArrayValue
+      removedArrayValue,
     ]);
   });
 
@@ -281,14 +281,14 @@ describe("Changes to the array properties with in a node", () => {
       { [AmfGraphTypes.KEY_NODE_ID]: "#/web-api/end-points/resource" },
       {
         [AmfGraphTypes.KEY_NODE_ID]:
-          "#/web-api/end-points/resource/{resourceId}"
-      }
+          "#/web-api/end-points/resource/{resourceId}",
+      },
     ];
     baseGraph[AmfGraphTypes.KEY_GRAPH][0]["apiContract:endpoint"] = arr;
 
     const newGraph = buildValidGraph();
     newGraph[AmfGraphTypes.KEY_GRAPH][0]["apiContract:endpoint"] = [
-      ...arr
+      ...arr,
     ].reverse();
 
     const nodeChanges = findGraphChanges(baseGraph, newGraph);
@@ -311,7 +311,7 @@ describe("Changes to the reference node ID with in a node", () => {
   it("returns modified reference property", async () => {
     const baseGraph = buildValidGraph();
     const oldReferenceValue = {
-      [AmfGraphTypes.KEY_NODE_ID]: "#/declarations/securitySchemes/test"
+      [AmfGraphTypes.KEY_NODE_ID]: "#/declarations/securitySchemes/test",
     };
     baseGraph[AmfGraphTypes.KEY_GRAPH][1][
       "security:scheme"
@@ -319,7 +319,8 @@ describe("Changes to the reference node ID with in a node", () => {
 
     const newGraph = buildValidGraph();
     const newReferenceValue = {
-      [AmfGraphTypes.KEY_NODE_ID]: "#/declarations/securitySchemes/test-updated"
+      [AmfGraphTypes.KEY_NODE_ID]:
+        "#/declarations/securitySchemes/test-updated",
     };
     newGraph[AmfGraphTypes.KEY_GRAPH][1]["security:scheme"] = newReferenceValue;
 
@@ -340,20 +341,20 @@ describe("Changes to the reference node ID with in a node", () => {
         {
           [AmfGraphTypes.KEY_NODE_ID]: "#/web-api",
           [AmfGraphTypes.KEY_NODE_TYPE]: ["apiContract:WebAPI"],
-          reference: { [AmfGraphTypes.KEY_NODE_ID]: "ref-node" }
-        }
+          reference: { [AmfGraphTypes.KEY_NODE_ID]: "ref-node" },
+        },
       ],
-      [AmfGraphTypes.KEY_CONTEXT]: { "@base": "test.raml" }
+      [AmfGraphTypes.KEY_CONTEXT]: { "@base": "test.raml" },
     };
     const newGraph = {
       [AmfGraphTypes.KEY_GRAPH]: [
         {
           [AmfGraphTypes.KEY_NODE_ID]: "#/web-api",
           [AmfGraphTypes.KEY_NODE_TYPE]: ["apiContract:WebAPI"],
-          reference: { prop: "test" } //this is invalid, reference should have only @id property
-        }
+          reference: { prop: "test" }, //this is invalid, reference should have only @id property
+        },
       ],
-      [AmfGraphTypes.KEY_CONTEXT]: { "@base": "test.raml" }
+      [AmfGraphTypes.KEY_CONTEXT]: { "@base": "test.raml" },
     };
 
     expect(() => findGraphChanges(baseGraph, newGraph)).to.throw(

--- a/src/diff/amfGraphDifferencer.ts
+++ b/src/diff/amfGraphDifferencer.ts
@@ -20,7 +20,7 @@ export enum DeltaType {
   REMOVED,
   MODIFIED,
   TEXT_DIFF,
-  MOVED
+  MOVED,
 }
 
 /**
@@ -59,12 +59,12 @@ export function findGraphChanges(
       // detect items moved inside the array (otherwise they will be registered as remove+add). This flag defaults to true if not specified
       detectMove: true,
       // include the value of items moved so that we can have node ids in the diffs. This flag defaults to false if not specified
-      includeValueOnMove: true
+      includeValueOnMove: true,
     },
     textDiff: {
       // minimum string length (baseGraph and newGraph sides) to use text diff algorithm: google-diff-match-patch. Default value if not specified is 60
-      minLength: 6000
-    }
+      minLength: 6000,
+    },
   });
   //add plugin to include ID of the node in the delta
   jsonDiff.processor.pipes.diff.before("collectChildren", addNodeInfo);
@@ -150,9 +150,9 @@ function parseGraphDelta(
   const graphChanges: NodeChanges[] = [];
   //Ignore the property added by jsondiffpath to indicate an array
   const keys = Object.keys(graphDelta).filter(
-    key => key !== AmfGraphDeltaTypes.ARRAY_KEY
+    (key) => key !== AmfGraphDeltaTypes.ARRAY_KEY
   );
-  keys.forEach(key => {
+  keys.forEach((key) => {
     const nodeDelta = graphDelta[key];
     let nodeChanges;
     if (_.isArray(nodeDelta)) {
@@ -204,10 +204,10 @@ function parseNodePropDelta(
   let nodeChanges = new NodeChanges(nodeId, nodeType);
   //ignore node id and type
   const keys = Object.keys(nodeDelta).filter(
-    key =>
+    (key) =>
       key !== AmfGraphTypes.KEY_NODE_ID && key !== AmfGraphTypes.KEY_NODE_TYPE
   );
-  keys.forEach(key => {
+  keys.forEach((key) => {
     const value = nodeDelta[key];
     if (_.isArray(value)) {
       parsePropertyDelta(
@@ -376,9 +376,9 @@ export function parseArrayDelta(
   nodeChanges: NodeChanges
 ): void {
   const indexKeys = Object.keys(delta).filter(
-    key => key !== AmfGraphDeltaTypes.ARRAY_KEY
+    (key) => key !== AmfGraphDeltaTypes.ARRAY_KEY
   );
-  indexKeys.forEach(k => {
+  indexKeys.forEach((k) => {
     //Since this is flattened graph array value is either a string or a object with an id referencing other object in the graph
     const arrValue = delta[k];
     const deltaType = getDeltaType(arrValue);
@@ -445,10 +445,10 @@ function parseReferenceNodeDelta(
   switch (deltaType) {
     case DeltaType.MODIFIED:
       nodeChanges.removed[nodeProperty] = {
-        [AmfGraphTypes.KEY_NODE_ID]: deltaValues[0]
+        [AmfGraphTypes.KEY_NODE_ID]: deltaValues[0],
       };
       nodeChanges.added[nodeProperty] = {
-        [AmfGraphTypes.KEY_NODE_ID]: deltaValues[1]
+        [AmfGraphTypes.KEY_NODE_ID]: deltaValues[1],
       };
       break;
     case DeltaType.TEXT_DIFF:
@@ -464,14 +464,14 @@ function parseReferenceNodeDelta(
 /**
  * jsondiffpatch plugin to add node ID and type to the node delta
  */
-const addNodeInfo = function(context): void {
+const addNodeInfo = function (context): void {
   if (
     context.leftType === "object" &&
     typeof context.left[AmfGraphTypes.KEY_NODE_ID] !== "undefined"
   ) {
     const changed = !!_.find(
       context.children,
-      childContext => childContext.result
+      (childContext) => childContext.result
     );
     if (changed) {
       context.setResult({
@@ -482,7 +482,7 @@ const addNodeInfo = function(context): void {
          */
         [AmfGraphTypes.KEY_NODE_ID]: context.right[AmfGraphTypes.KEY_NODE_ID],
         [AmfGraphTypes.KEY_NODE_TYPE]:
-          context.right[AmfGraphTypes.KEY_NODE_TYPE]
+          context.right[AmfGraphTypes.KEY_NODE_TYPE],
       });
     }
   }

--- a/src/diff/apiDifferencer.test.ts
+++ b/src/diff/apiDifferencer.test.ts
@@ -37,7 +37,7 @@ describe("Test RAML differencing", () => {
       tmpFile.name
     );
     const categorizedChanges = apiChanges.nodeChanges.find(
-      nodeChanges => nodeChanges.id === "#/web-api"
+      (nodeChanges) => nodeChanges.id === "#/web-api"
     ).categorizedChanges;
 
     expect(apiChanges.hasChanges()).to.be.true;
@@ -55,7 +55,7 @@ describe("Test RAML differencing", () => {
     const apiChanges = await apiDifferencer.findAndCategorizeChanges();
     expect(apiChanges.hasChanges()).to.equal(true);
     const categorizedChanges = apiChanges.nodeChanges.find(
-      nodeChanges => nodeChanges.id === "#/web-api"
+      (nodeChanges) => nodeChanges.id === "#/web-api"
     ).categorizedChanges;
 
     expect(categorizedChanges).to.have.length(1);
@@ -75,28 +75,28 @@ function buildRule(): Rule {
           fact: DIFF_FACT_ID,
           path: "$.type",
           operator: "contains",
-          value: "apiContract:WebAPI"
+          value: "apiContract:WebAPI",
         },
         {
           fact: DIFF_FACT_ID,
           path: "$.added",
           operator: "hasProperty",
-          value: "core:name"
+          value: "core:name",
         },
         {
           fact: DIFF_FACT_ID,
           path: "$.removed",
           operator: "hasProperty",
-          value: "core:name"
-        }
-      ]
+          value: "core:name",
+        },
+      ],
     },
     event: {
       type: "api-title-change",
       params: {
         category: RuleCategory.BREAKING,
-        changedProperty: "core:name"
-      }
-    }
+        changedProperty: "core:name",
+      },
+    },
   });
 }

--- a/src/diff/apiDifferencer.ts
+++ b/src/diff/apiDifferencer.ts
@@ -40,7 +40,7 @@ export class ApiDifferencer {
   async findChanges(): Promise<ApiChanges> {
     const [leftGraph, rightGraph] = await Promise.all([
       this.generateGraph(this.baseApiSpec),
-      this.generateGraph(this.newApiSpec)
+      this.generateGraph(this.newApiSpec),
     ]);
     ramlToolLogger.info(
       `Finding differences between flattened JSON-LD of ${this.baseApiSpec} and ${this.newApiSpec}`

--- a/src/diff/changes/apiChanges.ts
+++ b/src/diff/changes/apiChanges.ts
@@ -34,14 +34,14 @@ export class ApiChanges {
    * Get nodes that has categorized changes
    */
   getCategorizedChanges(): NodeChanges[] {
-    return this.nodeChanges.filter(n => n.hasCategorizedChanges());
+    return this.nodeChanges.filter((n) => n.hasCategorizedChanges());
   }
 
   /**
    * Return true if there are breaking changes
    */
   hasBreakingChanges(): boolean {
-    return this.nodeChanges.some(n => n.hasBreakingChanges());
+    return this.nodeChanges.some((n) => n.hasBreakingChanges());
   }
 
   /**

--- a/src/diff/changes/apiCollectionChanges.ts
+++ b/src/diff/changes/apiCollectionChanges.ts
@@ -41,7 +41,7 @@ export class ApiCollectionChanges {
     if (this.removed.length > 0 || this.added.length > 0) {
       return true;
     }
-    return Object.values(this.changed).some(apiChanges =>
+    return Object.values(this.changed).some((apiChanges) =>
       apiChanges.hasChanges()
     );
   }

--- a/src/diff/changes/nodeChanges.ts
+++ b/src/diff/changes/nodeChanges.ts
@@ -40,7 +40,7 @@ export class NodeChanges {
    */
   hasBreakingChanges(): boolean {
     return this.categorizedChanges.some(
-      c => c.category === RuleCategory.BREAKING
+      (c) => c.category === RuleCategory.BREAKING
     );
   }
 
@@ -49,7 +49,7 @@ export class NodeChanges {
    */
   hasIgnoredChanges(): boolean {
     return this.categorizedChanges.some(
-      c => c.category === RuleCategory.IGNORED
+      (c) => c.category === RuleCategory.IGNORED
     );
   }
 
@@ -58,7 +58,8 @@ export class NodeChanges {
    * @param category - category of the change
    */
   getChangeCountByCategory(category: RuleCategory): number {
-    return this.categorizedChanges.filter(c => c.category === category).length;
+    return this.categorizedChanges.filter((c) => c.category === category)
+      .length;
   }
 
   /**

--- a/src/diff/customOperators.test.ts
+++ b/src/diff/customOperators.test.ts
@@ -24,7 +24,7 @@ function verifyRule(nodeChanges: NodeChanges, rule: Rule): void {
   if (rule.event.params.changedProperty) {
     changedValues = [
       nodeChanges.removed[rule.event.params.changedProperty],
-      nodeChanges.added[rule.event.params.changedProperty]
+      nodeChanges.added[rule.event.params.changedProperty],
     ];
   }
   expect(categorizedChanges).to.have.length(1);
@@ -42,9 +42,9 @@ describe("Custom operators - hasProperty", () => {
           fact: DIFF_FACT_ID,
           path: "$.added",
           operator: "hasProperty",
-          value: "core:name"
-        }
-      ]
+          value: "core:name",
+        },
+      ],
     });
 
     const nodeChanges = await applyRules(
@@ -61,9 +61,9 @@ describe("Custom operators - hasProperty", () => {
           fact: DIFF_FACT_ID,
           path: "$.added",
           operator: "hasProperty",
-          value: "core:desc"
-        }
-      ]
+          value: "core:desc",
+        },
+      ],
     });
 
     const nodeChanges = await applyRules(
@@ -82,9 +82,9 @@ describe("Custom operators - hasNoProperty", () => {
           fact: DIFF_FACT_ID,
           path: "$.added",
           operator: "hasNoProperty",
-          value: "core:desc"
-        }
-      ]
+          value: "core:desc",
+        },
+      ],
     });
 
     const nodeChanges = await applyRules(
@@ -100,9 +100,9 @@ describe("Custom operators - hasNoProperty", () => {
           fact: DIFF_FACT_ID,
           path: "$.added",
           operator: "hasNoProperty",
-          value: "core:name"
-        }
-      ]
+          value: "core:name",
+        },
+      ],
     });
 
     const nodeChanges = await applyRules(
@@ -118,7 +118,7 @@ describe("Custom operators - hasNoProperty", () => {
  */
 function getDefaultNodeChanges(): NodeChanges {
   const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-    "apiContract:Operation"
+    "apiContract:Operation",
   ]);
   nodeChanges.added = { "core:name": "newName" };
   nodeChanges.removed = { "core:name": "oldName" };
@@ -137,9 +137,9 @@ function buildRule(conditions: TopLevelCondition): Rule {
       type: "test-rule",
       params: {
         category: RuleCategory.BREAKING,
-        changedProperty: "core:name"
-      }
-    }
+        changedProperty: "core:name",
+      },
+    },
   });
 }
 

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -28,7 +28,7 @@ function verifyRule(
   if (rule.event.params.changedProperty) {
     changedValues = [
       nodeChanges.removed[rule.event.params.changedProperty],
-      nodeChanges.added[rule.event.params.changedProperty]
+      nodeChanges.added[rule.event.params.changedProperty],
     ];
   }
   expect(categorizedChanges).to.have.lengthOf(countOfChanges);
@@ -41,7 +41,7 @@ function verifyRule(
 describe("Display name change", () => {
   it("applies display name change rule", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:Operation"
+      "apiContract:Operation",
     ]);
     nodeChanges.added = { "core:name": "newName" };
     nodeChanges.removed = { "core:name": "oldName" };
@@ -50,7 +50,7 @@ describe("Display name change", () => {
       ApiDifferencer.DEFAULT_RULES_PATH
     );
     const rule = defaultRules.find(
-      r => r.event.type === "display-name-changed"
+      (r) => r.event.type === "display-name-changed"
     );
     verifyRule(changes[0], rule);
   });
@@ -59,7 +59,7 @@ describe("Display name change", () => {
 describe("Operation removal", () => {
   it("applies operation removed rule", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:Operation"
+      "apiContract:Operation",
     ]);
     nodeChanges.added = {};
     nodeChanges.removed = { "core:name": "oldName" };
@@ -67,7 +67,7 @@ describe("Operation removal", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "operation-removed");
+    const rule = defaultRules.find((r) => r.event.type === "operation-removed");
     verifyRule(changes[0], rule);
   });
 });
@@ -75,7 +75,7 @@ describe("Operation removal", () => {
 describe("Parameter removal", () => {
   it("applies parameter removed rule", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:Parameter"
+      "apiContract:Parameter",
     ]);
     nodeChanges.added = {};
     nodeChanges.removed = { "core:name": "oldName" };
@@ -83,7 +83,7 @@ describe("Parameter removal", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "parameter-removed");
+    const rule = defaultRules.find((r) => r.event.type === "parameter-removed");
     verifyRule(changes[0], rule);
   });
 });
@@ -91,11 +91,11 @@ describe("Parameter removal", () => {
 describe("Required parameter addition", () => {
   it("applies required parameter added rule", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:Parameter"
+      "apiContract:Parameter",
     ]);
     nodeChanges.added = {
       "core:name": "newName",
-      "apiContract:required": true
+      "apiContract:required": true,
     };
     nodeChanges.removed = {};
     const changes = await applyRules(
@@ -103,7 +103,7 @@ describe("Required parameter addition", () => {
       ApiDifferencer.DEFAULT_RULES_PATH
     );
     const rule = defaultRules.find(
-      r => r.event.type === "required-parameter-added"
+      (r) => r.event.type === "required-parameter-added"
     );
     verifyRule(changes[0], rule);
   });
@@ -112,7 +112,7 @@ describe("Required parameter addition", () => {
 describe("Version change", () => {
   it("applies version change rule", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:WebAPI"
+      "apiContract:WebAPI",
     ]);
     nodeChanges.added = { "core:version": "v2" };
     nodeChanges.removed = { "core:version": "v1" };
@@ -120,7 +120,7 @@ describe("Version change", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "version-changed");
+    const rule = defaultRules.find((r) => r.event.type === "version-changed");
     verifyRule(changes[0], rule);
   });
 });
@@ -128,7 +128,7 @@ describe("Version change", () => {
 describe("Examples change", () => {
   it("does not apply ignore examples rule on a change that has no apiContract:Example node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:WebAPI"
+      "apiContract:WebAPI",
     ]);
     nodeChanges.added = { "core:version": "v2" };
     nodeChanges.removed = { "core:version": "v1" };
@@ -136,13 +136,13 @@ describe("Examples change", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-changed");
+    const rule = defaultRules.find((r) => r.event.type === "example-changed");
     expect(changes[0].categorizedChanges[0].ruleName).to.not.equal(rule.name);
   });
 
   it("does not apply ignore examples rule on a change that has undefined as the node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      undefined
+      undefined,
     ]);
     nodeChanges.added = { "core:version": "v2" };
     nodeChanges.removed = { "core:version": "v1" };
@@ -169,7 +169,7 @@ describe("Examples change", () => {
 
   it("applies ignore examples rule on a change that includes only one apiContract:Example node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:Example"
+      "apiContract:Example",
     ]);
     nodeChanges.added = { "core:description": "Old example" };
     nodeChanges.removed = { "core:description": "New example" };
@@ -177,13 +177,13 @@ describe("Examples change", () => {
       [nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-changed");
+    const rule = defaultRules.find((r) => r.event.type === "example-changed");
     verifyRule(changes[0], rule);
   });
 
   it("applies ignore examples rule changes that includes many apiContract:Example node type", async () => {
     const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
-      "apiContract:Example"
+      "apiContract:Example",
     ]);
     nodeChanges.added = { "core:description": "Old example" };
     nodeChanges.removed = { "core:description": "New example" };
@@ -191,7 +191,7 @@ describe("Examples change", () => {
       [nodeChanges, nodeChanges],
       ApiDifferencer.DEFAULT_RULES_PATH
     );
-    const rule = defaultRules.find(r => r.event.type === "example-changed");
+    const rule = defaultRules.find((r) => r.event.type === "example-changed");
     verifyRule(changes[0], rule, 2);
   });
 });

--- a/src/diff/diffCommand.test.ts
+++ b/src/diff/diffCommand.test.ts
@@ -112,7 +112,7 @@ describe("raml-toolkit cli diff command", () => {
     .stdout()
     .do(() => cmd.run(["--version"]))
     .exit(0)
-    .it("checks that the version string starts with the app name", ctx => {
+    .it("checks that the version string starts with the app name", (ctx) => {
       expect(ctx.stdout).to.contain("@commerce-apps/raml-toolkit");
     });
 
@@ -197,7 +197,7 @@ describe("raml-toolkit cli diff command", () => {
         ramlOld.name,
         ramlOld.name,
         "--ruleset",
-        operationRemovedRuleset.name
+        operationRemovedRuleset.name,
       ])
     )
     .exit(0)
@@ -211,7 +211,7 @@ describe("raml-toolkit cli diff command", () => {
         ramlOld.name,
         ramlAdded.name,
         "--ruleset",
-        operationRemovedRuleset.name
+        operationRemovedRuleset.name,
       ])
     )
     .exit(0)
@@ -224,7 +224,7 @@ describe("raml-toolkit cli diff command", () => {
         ramlOld.name,
         ramlRemoved.name,
         "--ruleset",
-        operationRemovedRuleset.name
+        operationRemovedRuleset.name,
       ])
     )
     .exit(1)
@@ -238,7 +238,7 @@ describe("raml-toolkit cli diff command", () => {
         ramlOld.name,
         "--diff-only",
         "--ruleset",
-        operationRemovedRuleset.name
+        operationRemovedRuleset.name,
       ])
     )
     .exit(2)
@@ -258,7 +258,7 @@ describe("raml-toolkit cli diff command", () => {
         ramlOld.name,
         "--dir",
         "--ruleset",
-        operationRemovedRuleset.name
+        operationRemovedRuleset.name,
       ])
     )
     .exit(2)

--- a/src/diff/diffCommand.ts
+++ b/src/diff/diffCommand.ts
@@ -40,22 +40,22 @@ Exit statuses:
       // Displaying the require()-able form is shorter and always the same.
       description: `[default:${ApiDifferencer.DEFAULT_RULES_PACKAGE_PATH}] Path to ruleset to apply to diff`,
       env: "DIFF_RULESET",
-      exclusive: ["diff-only", "dir"]
+      exclusive: ["diff-only", "dir"],
     }),
     "diff-only": flags.boolean({
       description: "Only show differences without evaluating a ruleset",
       default: false,
-      exclusive: ["ruleset", "dir"]
+      exclusive: ["ruleset", "dir"],
     }),
     dir: flags.boolean({
       description: "Find the differences for all files in two directories",
       default: false,
-      exclusive: ["ruleset", "diff-only"]
+      exclusive: ["ruleset", "diff-only"],
     }),
     "out-file": flags.string({
       char: "o",
-      description: "File to store the computed difference"
-    })
+      description: "File to store the computed difference",
+    }),
   };
 
   static args = [
@@ -63,14 +63,14 @@ Exit statuses:
       name: "base",
       required: true,
       description:
-        "The base API spec file (ruleset / diff-only mode) or configuration (directory mode)"
+        "The base API spec file (ruleset / diff-only mode) or configuration (directory mode)",
     },
     {
       name: "new",
       required: true,
       description:
-        "The new API spec file (ruleset / diff-only mode) or configuration (directory mode)"
-    }
+        "The new API spec file (ruleset / diff-only mode) or configuration (directory mode)",
+    },
   ];
 
   /**

--- a/src/diff/diffDirectories.test.ts
+++ b/src/diff/diffDirectories.test.ts
@@ -25,15 +25,15 @@ describe("diffRamlDirectories", () => {
   const apiConfig = {
     family1: [
       { assetId: "api1", fatRaml: { mainFile: "api1.raml" } },
-      { assetId: "api2", fatRaml: { mainFile: "api2.raml" } }
+      { assetId: "api2", fatRaml: { mainFile: "api2.raml" } },
     ],
     family2: [
       { assetId: "api3", fatRaml: { mainFile: "api3.raml" } },
-      { assetId: "api4", fatRaml: { mainFile: "api4.raml" } }
-    ]
+      { assetId: "api4", fatRaml: { mainFile: "api4.raml" } },
+    ],
   };
   const nodeChanges = new NodeChanges("#/web-api/endpoints/test-endpoint", [
-    "apiContract:Endpoint"
+    "apiContract:Endpoint",
   ]);
   const apiChanges = new ApiChanges("api1/api1.raml", "api2/api2.raml");
   apiChanges.nodeChanges = [nodeChanges];
@@ -140,7 +140,7 @@ describe("diffRamlDirectories", () => {
     expect(apiDifferencerStub.calledTwice).to.be.true;
     expect(apiCollectionChanges.removed).to.have.members([
       "api3/api3.raml",
-      "api4/api4.raml"
+      "api4/api4.raml",
     ]);
   });
 
@@ -169,7 +169,7 @@ describe("diffRamlDirectories", () => {
     expect(apiDifferencerStub.calledTwice).to.be.true;
     expect(apiCollectionChanges.added).to.have.members([
       "api3/api3.raml",
-      "api4/api4.raml"
+      "api4/api4.raml",
     ]);
   });
 

--- a/src/diff/diffDirectories.ts
+++ b/src/diff/diffDirectories.ts
@@ -51,7 +51,7 @@ function getCommonAndUniqueElements<T>(
   const left = new Set(leftArr);
   const right = new Set(rightArr);
   const common = new Set<T>();
-  left.forEach(val => {
+  left.forEach((val) => {
     if (right.has(val)) {
       left.delete(val);
       right.delete(val);
@@ -60,7 +60,7 @@ function getCommonAndUniqueElements<T>(
   });
   return {
     common: [...common],
-    unique: [[...left], [...right]]
+    unique: [[...left], [...right]],
   };
 }
 

--- a/src/diff/ruleSet.test.ts
+++ b/src/diff/ruleSet.test.ts
@@ -27,29 +27,29 @@ function buildDefaultRule(): Rule {
           fact: DIFF_FACT_ID,
           path: "$.type",
           operator: "contains",
-          value: "apiContract:WebAPI"
+          value: "apiContract:WebAPI",
         },
         {
           fact: DIFF_FACT_ID,
           path: "$.added",
           operator: "hasProperty",
-          value: "core:name"
+          value: "core:name",
         },
         {
           fact: DIFF_FACT_ID,
           path: "$.removed",
           operator: "hasProperty",
-          value: "core:name"
-        }
-      ]
+          value: "core:name",
+        },
+      ],
     },
     event: {
       type: "api-title-change",
       params: {
         category: "Breaking",
-        changedProperty: "core:name"
-      }
-    }
+        changedProperty: "core:name",
+      },
+    },
   });
 }
 

--- a/src/diff/ruleSet.ts
+++ b/src/diff/ruleSet.ts
@@ -13,7 +13,7 @@ import fs from "fs-extra";
 export enum RuleCategory {
   BREAKING = "Breaking",
   NON_BREAKING = "Non-Breaking",
-  IGNORED = "Ignored"
+  IGNORED = "Ignored",
 }
 
 /**
@@ -45,7 +45,7 @@ export class RuleSet {
     }
 
     try {
-      const rules = ruleJsonArray.map(r => new Rule(r));
+      const rules = ruleJsonArray.map((r) => new Rule(r));
       return new RuleSet(rules);
     } catch (error) {
       error.message = `Error parsing the rule: ${error.message}`;
@@ -57,7 +57,7 @@ export class RuleSet {
    * Validate properties of the rule required for the Diff
    */
   validateRuleProperties(): void {
-    this.rules.forEach(r => {
+    this.rules.forEach((r) => {
       if (!r.name) {
         throw new Error("Name is required for every rule");
       }

--- a/src/diff/rulesProcessor.ts
+++ b/src/diff/rulesProcessor.ts
@@ -9,7 +9,7 @@ import {
   Event,
   Almanac,
   RuleResult,
-  EngineResult
+  EngineResult,
 } from "json-rules-engine";
 import { CategorizedChange } from "./changes/categorizedChange";
 import { NodeChanges } from "./changes/nodeChanges";
@@ -44,7 +44,7 @@ export async function applyRules(
   //callback function to execute when a rule is passed/evaluates to true
   engine.on("success", successHandler);
   //Add custom operators to use in rules
-  customOperators.map(o => engine.addOperator(o));
+  customOperators.map((o) => engine.addOperator(o));
 
   /**
    * run rules on nodeChanges
@@ -52,7 +52,7 @@ export async function applyRules(
    * Result from the engine run is processed by the callback, the success handler. So the "EngineResult" returned by the runEngine function is ignored here.
    * Also callback has access to RuleResult which has all the details of the rule that is applied whereas EngineResult do not
    */
-  const promises = nodeChanges.map(diff => {
+  const promises = nodeChanges.map((diff) => {
     return runEngine(engine, diff);
   });
   await Promise.all(promises);
@@ -79,7 +79,7 @@ async function successHandler(
   if (event.params.changedProperty) {
     changedValues = [
       nodeChanges.removed[event.params.changedProperty],
-      nodeChanges.added[event.params.changedProperty]
+      nodeChanges.added[event.params.changedProperty],
     ];
   }
   nodeChanges.categorizedChanges.push(

--- a/src/download/bearerToken.test.ts
+++ b/src/download/bearerToken.test.ts
@@ -20,9 +20,9 @@ describe("Test Auth", () => {
       .post("/accounts/login", { username: "user", password: "pass" })
       .reply(200, {
         // eslint-disable-next-line @typescript-eslint/camelcase
-        access_token: "AUTH_TOKEN_HERE"
+        access_token: "AUTH_TOKEN_HERE",
       });
-    return getBearer("user", "pass").then(s => {
+    return getBearer("user", "pass").then((s) => {
       expect(s).to.equals("AUTH_TOKEN_HERE");
     });
   });

--- a/src/download/bearerToken.ts
+++ b/src/download/bearerToken.ts
@@ -12,15 +12,15 @@ export function getBearer(username: string, password: string): Promise<string> {
   return fetch(MULESOFT_LOGIN, {
     method: "post",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       username: username,
-      password: password
-    })
+      password: password,
+    }),
   }).then((response: Response) => {
     if (response.ok) {
-      return response.json().then(json => json["access_token"]);
+      return response.json().then((json) => json["access_token"]);
     }
 
     switch (response.status) {

--- a/src/download/exchangeDirectoryParser.test.ts
+++ b/src/download/exchangeDirectoryParser.test.ts
@@ -20,7 +20,7 @@ async function createZipFile(
 ): Promise<void> {
   const zip = new JSZip();
 
-  return new Promise(resolve =>
+  return new Promise((resolve) =>
     zip
       .file("exchange.json", "{}")
       .generateNodeStream({ type: "nodebuffer", streamFiles: true })

--- a/src/download/exchangeDirectoryParser.ts
+++ b/src/download/exchangeDirectoryParser.ts
@@ -10,7 +10,7 @@ import unzipper from "unzipper";
 
 function getFiles(directory): fs.Dirent[] {
   return fs.readdirSync(path.join(directory), {
-    withFileTypes: true
+    withFileTypes: true,
   });
 }
 
@@ -29,8 +29,8 @@ export function extractFiles(
   const files = getFiles(directory);
   const promises: Promise<void>[] = [];
   files
-    .filter(file => file.isFile() && path.extname(file.name) === ".zip")
-    .forEach(file => {
+    .filter((file) => file.isFile() && path.extname(file.name) === ".zip")
+    .forEach((file) => {
       promises.push(
         new Promise((resolve, reject) => {
           fs.createReadStream(
@@ -41,7 +41,7 @@ export function extractFiles(
                 path: path.join(
                   path.resolve(directory),
                   path.basename(file.name, ".zip")
-                )
+                ),
               })
               .on("error", reject)
               .on("close", () => {

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -11,7 +11,7 @@ import {
   getVersionByDeployment,
   getSpecificApi,
   getAsset,
-  search
+  search,
 } from "./exchangeDownloader";
 import { RestApi } from "./exchangeTypes";
 import { searchAssetApiResultObject } from "../../testResources/download/resources/restApiResponseObjects";
@@ -49,9 +49,9 @@ const REST_API: RestApi = {
     externalLink: "https://somewhere/fatraml.zip",
     packaging: "zip",
     createdDate: "today",
-    mainFile: "api.raml"
+    mainFile: "api.raml",
   },
-  version: "1.0.0"
+  version: "1.0.0",
 };
 
 describe("downloadRestApi", () => {
@@ -60,9 +60,7 @@ describe("downloadRestApi", () => {
   it("can download a single file", async () => {
     const tmpDir = tmp.dirSync();
 
-    nock("https://somewhere")
-      .get("/fatraml.zip")
-      .reply(200);
+    nock("https://somewhere").get("/fatraml.zip").reply(200);
 
     const api = _.cloneDeep(REST_API);
 
@@ -72,9 +70,7 @@ describe("downloadRestApi", () => {
   });
 
   it("can download a single file even when no download dir is specified", async () => {
-    nock("https://somewhere")
-      .get("/fatraml.zip")
-      .reply(200);
+    nock("https://somewhere").get("/fatraml.zip").reply(200);
 
     const api = _.cloneDeep(REST_API);
 
@@ -106,7 +102,7 @@ describe("downloadRestApis", () => {
     scope.get("/fatraml.zip").reply(200);
     scope.get("/fatraml2.zip").reply(200);
 
-    return downloadRestApis(apis, tmpDir.name).then(res => {
+    return downloadRestApis(apis, tmpDir.name).then((res) => {
       expect(res).to.equal(tmpDir.name);
     });
   });
@@ -121,13 +117,13 @@ describe("downloadRestApis", () => {
     scope.get("/fatraml.zip").reply(200);
     scope.get("/fatraml2.zip").reply(200);
 
-    return downloadRestApis(apis).then(res => {
+    return downloadRestApis(apis).then((res) => {
       expect(res).to.equal("download");
     });
   });
 
   it("should not do anything when an empty list is passed", async () => {
-    return downloadRestApis([]).then(res => {
+    return downloadRestApis([]).then((res) => {
       expect(res).to.equal("download");
     });
   });
@@ -143,7 +139,7 @@ describe("searchExchange", () => {
       .get("/assets?search=searchString&types=rest-api")
       .reply(200, assetSearchResults);
 
-    return searchExchange("AUTH_TOKEN", "searchString").then(res => {
+    return searchExchange("AUTH_TOKEN", "searchString").then((res) => {
       expect(res).to.deep.equal(searchAssetApiResultObject);
     });
   });
@@ -179,7 +175,7 @@ describe("getSpecificApi", () => {
         "API layer": ["Process"],
         "CC API Visibility": ["External"],
         "CC Version Status": ["Beta"],
-        "CC API Family": ["Customer"]
+        "CC API Family": ["Customer"],
       },
       fatRaml: {
         classifier: "fat-raml",
@@ -189,8 +185,8 @@ describe("getSpecificApi", () => {
         createdDate: "2020-01-22T03:25:00.200Z",
         md5: "3ce41ea699c8be4446909f172cfac317",
         sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
-        mainFile: "shopper-customers.raml"
-      }
+        mainFile: "shopper-customers.raml",
+      },
     });
   });
 
@@ -328,8 +324,8 @@ describe("search", () => {
     // Intercept searchExchange request
     nock("https://anypoint.mulesoft.com/exchange/api/v2", {
       reqheaders: {
-        Authorization: "Bearer AUTH_TOKEN"
-      }
+        Authorization: "Bearer AUTH_TOKEN",
+      },
     })
       .get("/assets?search=searchString")
       .reply(200, [assetSearchResults[0]]);
@@ -356,7 +352,7 @@ describe("search", () => {
           "API layer": ["Process"],
           "CC API Visibility": ["External"],
           "CC Version Status": ["Beta"],
-          "CC API Family": ["Customer"]
+          "CC API Family": ["Customer"],
         },
         fatRaml: {
           classifier: "fat-raml",
@@ -366,9 +362,9 @@ describe("search", () => {
           createdDate: "2020-01-22T03:25:00.200Z",
           md5: "3ce41ea699c8be4446909f172cfac317",
           sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
-          mainFile: "shopper-customers.raml"
-        }
-      }
+          mainFile: "shopper-customers.raml",
+        },
+      },
     ]);
   });
 
@@ -388,7 +384,7 @@ describe("search", () => {
           "API layer": ["Process"],
           "CC API Family": ["Product"],
           "CC Version Status": ["Beta"],
-          "CC API Visibility": ["External"]
+          "CC API Visibility": ["External"],
         },
         fatRaml: {
           classifier: "fat-raml",
@@ -396,9 +392,9 @@ describe("search", () => {
           createdDate: null,
           md5: null,
           sha1: null,
-          mainFile: "shop-products-categories-api-v1.raml"
-        }
-      }
+          mainFile: "shop-products-categories-api-v1.raml",
+        },
+      },
     ]);
   });
 
@@ -425,7 +421,7 @@ describe("search", () => {
           "CC API Visibility": ["External"],
           "CC Version Status": ["Beta"],
           "CC API Family": ["Customer"],
-          "API layer": ["Process"]
+          "API layer": ["Process"],
         },
         fatRaml: {
           classifier: "fat-raml",
@@ -435,9 +431,9 @@ describe("search", () => {
           createdDate: "2020-02-05T21:26:01.199Z",
           md5: "87b3ad2b2aa17639b52f0cc83c5a8d40",
           sha1: "f2b9b2de50b7250616e2eea8843735b57235c22b",
-          mainFile: "shopper-customers.raml"
-        }
-      }
+          mainFile: "shopper-customers.raml",
+        },
+      },
     ]);
   });
 });

--- a/src/download/exchangeDownloader.ts
+++ b/src/download/exchangeDownloader.ts
@@ -17,7 +17,7 @@ import {
   RestApi,
   FileInfo,
   RawCategories,
-  Categories
+  Categories,
 } from "./exchangeTypes";
 import { ramlToolLogger } from "../common/logger";
 
@@ -51,21 +51,23 @@ export async function downloadRestApis(
   restApi: RestApi[],
   destinationFolder: string = DEFAULT_DOWNLOAD_FOLDER
 ): Promise<string> {
-  const downloads = restApi.map(api => downloadRestApi(api, destinationFolder));
+  const downloads = restApi.map((api) =>
+    downloadRestApi(api, destinationFolder)
+  );
   await Promise.all(downloads);
   return destinationFolder;
 }
 
 function mapCategories(categories: RawCategories[]): Categories {
   const cats: Categories = {};
-  categories.forEach(category => {
+  categories.forEach((category) => {
     cats[category.key] = category.value;
   });
   return cats;
 }
 
 function getFileByClassifier(files: FileInfo[], classifier: string): FileInfo {
-  const found = files.find(file => file.classifier === classifier);
+  const found = files.find((file) => file.classifier === classifier);
   // There are extra properties we don't want (downloadURL, isGenerated), so we
   // create a new object that excludes them
   return {
@@ -75,7 +77,7 @@ function getFileByClassifier(files: FileInfo[], classifier: string): FileInfo {
     createdDate: found.createdDate,
     md5: found.md5,
     sha1: found.sha1,
-    mainFile: found.mainFile
+    mainFile: found.mainFile,
   };
 }
 
@@ -89,7 +91,7 @@ function convertResponseToRestApi(apiResponse: RawRestApi): RestApi {
     assetId: apiResponse.assetId,
     version: apiResponse.version,
     categories: mapCategories(apiResponse.categories),
-    fatRaml: getFileByClassifier(apiResponse.files, "fat-raml")
+    fatRaml: getFileByClassifier(apiResponse.files, "fat-raml"),
   };
 }
 
@@ -110,8 +112,8 @@ export async function getAsset(
 ): Promise<void | RawRestApi> {
   const res = await fetch(`${ANYPOINT_BASE_URI}/assets/${assetId}`, {
     headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
   if (!res.ok) {
     ramlToolLogger.warn(
@@ -139,14 +141,14 @@ export async function searchExchange(
     `${ANYPOINT_BASE_URI}/assets?search=${searchString}&types=rest-api`,
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`
-      }
+        Authorization: `Bearer ${accessToken}`,
+      },
     }
   )
-    .then(res => res.json())
-    .then(restApis => {
+    .then((res) => res.json())
+    .then((restApis) => {
       const apis: RestApi[] = [];
-      restApis.forEach(restApi => {
+      restApis.forEach((restApi) => {
         apis.push(convertResponseToRestApi(restApi));
       });
       return apis;
@@ -175,7 +177,7 @@ export async function getVersionByDeployment(
     return;
   }
   let version = null;
-  asset.instances.forEach(instance => {
+  asset.instances.forEach((instance) => {
     if (
       instance.environmentName &&
       deployment.test(instance.environmentName) &&
@@ -229,7 +231,7 @@ export async function search(
     process.env.ANYPOINT_PASSWORD
   );
   const apis = await searchExchange(token, query);
-  const promises = apis.map(async api => {
+  const promises = apis.map(async (api) => {
     const version = await getVersionByDeployment(token, api, deployment);
     return version
       ? getSpecificApi(token, api.groupId, api.assetId, version)

--- a/src/download/exchangeTools.test.ts
+++ b/src/download/exchangeTools.test.ts
@@ -7,7 +7,7 @@
 import {
   groupByCategory,
   removeRamlLinks,
-  removeVersionSpecificInformation
+  removeVersionSpecificInformation,
 } from "./exchangeTools";
 import { RestApi } from "./exchangeTypes";
 
@@ -27,54 +27,54 @@ describe("Test groupByCategory method", () => {
       name: "Test API",
       groupId: "8888888",
       assetId: "test-api",
-      version: "1.0.0"
+      version: "1.0.0",
     },
     {
       id: "8888888/test-api-2/1.0.0",
       name: "Test API 2",
       groupId: "8888888",
       assetId: "test-api-2",
-      version: "1.0.0"
+      version: "1.0.0",
     },
     {
       id: "8888888/test-api-3/1.0.0",
       name: "Test API 3",
       groupId: "8888888",
       assetId: "test-api-3",
-      version: "1.0.0"
+      version: "1.0.0",
     },
     {
       id: "8888888/test-api-4/1.0.0",
       name: "Test API 4",
       groupId: "8888888",
       assetId: "test-api-4",
-      version: "1.0.0"
-    }
+      version: "1.0.0",
+    },
   ];
 
   it("Group Apis with all same category", () => {
     const safeApisObject = _.cloneDeep(apis);
-    safeApisObject.forEach(api => {
+    safeApisObject.forEach((api) => {
       api.categories = {
-        "Api Family": ["something"]
+        "Api Family": ["something"],
       };
     });
 
     expect(groupByCategory(safeApisObject, "Api Family")).to.deep.equal({
-      something: safeApisObject
+      something: safeApisObject,
     });
   });
 
   it("Group Apis with all same category w/o allowing unclassified", () => {
     const safeApisObject = _.cloneDeep(apis);
-    safeApisObject.forEach(api => {
+    safeApisObject.forEach((api) => {
       api.categories = {
-        "Api Family": ["something"]
+        "Api Family": ["something"],
       };
     });
 
     expect(groupByCategory(safeApisObject, "Api Family", false)).to.deep.equal({
-      something: safeApisObject
+      something: safeApisObject,
     });
   });
 
@@ -82,21 +82,21 @@ describe("Test groupByCategory method", () => {
     const safeApisObject = _.cloneDeep(apis);
 
     safeApisObject[0].categories = {
-      "Api Family": ["foo"]
+      "Api Family": ["foo"],
     };
     safeApisObject[1].categories = {
-      "Api Family": ["bar"]
+      "Api Family": ["bar"],
     };
     safeApisObject[2].categories = {
-      "Api Family": ["foo"]
+      "Api Family": ["foo"],
     };
     safeApisObject[3].categories = {
-      "Api Family": ["bar"]
+      "Api Family": ["bar"],
     };
 
     expect(groupByCategory(safeApisObject, "Api Family")).to.deep.equal({
       foo: [safeApisObject[0], safeApisObject[2]],
-      bar: [safeApisObject[1], safeApisObject[3]]
+      bar: [safeApisObject[1], safeApisObject[3]],
     });
   });
 
@@ -104,23 +104,23 @@ describe("Test groupByCategory method", () => {
     const safeApisObject = _.cloneDeep(apis);
 
     safeApisObject[0].categories = {
-      "Api Family": ["foo"]
+      "Api Family": ["foo"],
     };
     safeApisObject[1].categories = {
-      "Api Family": ["bar"]
+      "Api Family": ["bar"],
     };
     safeApisObject[2].categories = {
-      "Api Family": ["see"]
+      "Api Family": ["see"],
     };
     safeApisObject[3].categories = {
-      "Api Family": ["dog"]
+      "Api Family": ["dog"],
     };
 
     expect(groupByCategory(safeApisObject, "Api Family")).to.deep.equal({
       foo: [safeApisObject[0]],
       bar: [safeApisObject[1]],
       see: [safeApisObject[2]],
-      dog: [safeApisObject[3]]
+      dog: [safeApisObject[3]],
     });
   });
 
@@ -128,20 +128,20 @@ describe("Test groupByCategory method", () => {
     const safeApisObject = _.cloneDeep(apis);
 
     safeApisObject[0].categories = {
-      "Api Family": ["foo"]
+      "Api Family": ["foo"],
     };
     safeApisObject[2].categories = {
-      "Api Family": ["see"]
+      "Api Family": ["see"],
     };
     safeApisObject[3].categories = {
-      "Api Family": ["dog"]
+      "Api Family": ["dog"],
     };
 
     expect(groupByCategory(safeApisObject, "Api Family")).to.deep.equal({
       foo: [safeApisObject[0]],
       see: [safeApisObject[2]],
       dog: [safeApisObject[3]],
-      unclassified: [safeApisObject[1]]
+      unclassified: [safeApisObject[1]],
     });
   });
 
@@ -149,15 +149,15 @@ describe("Test groupByCategory method", () => {
     const safeApisObject = _.cloneDeep(apis);
 
     safeApisObject[0].categories = {
-      "Api Family": ["foo"]
+      "Api Family": ["foo"],
     };
     safeApisObject[2].categories = {};
 
     safeApisObject[2].categories = {
-      "Api Family": ["see"]
+      "Api Family": ["see"],
     };
     safeApisObject[3].categories = {
-      "Api Family": ["dog"]
+      "Api Family": ["dog"],
     };
 
     expect(() => groupByCategory(safeApisObject, "Api Family", false)).to.throw(
@@ -169,24 +169,24 @@ describe("Test groupByCategory method", () => {
     const safeApisObject = _.cloneDeep(apis);
 
     safeApisObject[0].categories = {
-      "Api Family": ["foo"]
+      "Api Family": ["foo"],
     };
     safeApisObject[2].categories = {
-      "CC Api Family": ["bar"]
+      "CC Api Family": ["bar"],
     };
 
     safeApisObject[2].categories = {
-      "Api Family": ["see"]
+      "Api Family": ["see"],
     };
     safeApisObject[3].categories = {
-      "Api Family": ["dog"]
+      "Api Family": ["dog"],
     };
 
     expect(groupByCategory(safeApisObject, "Api Family")).to.deep.equal({
       foo: [safeApisObject[0]],
       see: [safeApisObject[2]],
       dog: [safeApisObject[3]],
-      unclassified: [safeApisObject[1]]
+      unclassified: [safeApisObject[1]],
     });
   });
 });
@@ -204,8 +204,8 @@ const REST_APIS: RestApi[] = [
       externalLink: "https://somewhere/fatraml.zip",
       packaging: "zip",
       createdDate: "today",
-      mainFile: "api.raml"
-    }
+      mainFile: "api.raml",
+    },
   },
   {
     id: "8888888/test-api2/1.0.0",
@@ -219,27 +219,27 @@ const REST_APIS: RestApi[] = [
       externalLink: "https://somewhere/fatraml2.zip",
       packaging: "zip",
       createdDate: "today",
-      mainFile: "api.raml"
-    }
-  }
+      mainFile: "api.raml",
+    },
+  },
 ];
 
 describe("removeRamlLinks", () => {
   it("should remove fat RAML external links for all the apis", () => {
     const apis = _.cloneDeep(REST_APIS);
     removeRamlLinks(apis).forEach(
-      api => expect(api.fatRaml.externalLink).to.be.undefined
+      (api) => expect(api.fatRaml.externalLink).to.be.undefined
     );
   });
 
   it("should not fail if the RAML does not have externalLink fields", () => {
     const apis = _.cloneDeep(REST_APIS);
-    apis.forEach(apiEntry => {
+    apis.forEach((apiEntry) => {
       delete apiEntry.fatRaml.externalLink;
     });
 
     removeRamlLinks(apis).forEach(
-      api => expect(api.fatRaml.externalLink).to.be.undefined
+      (api) => expect(api.fatRaml.externalLink).to.be.undefined
     );
   });
 

--- a/src/download/exchangeTools.ts
+++ b/src/download/exchangeTools.ts
@@ -20,7 +20,7 @@ export function groupByCategory(
   groupBy: string,
   allowUnclassified = true
 ): { [key: string]: RestApi[] } {
-  return _.groupBy(apis, api => {
+  return _.groupBy(apis, (api) => {
     // Categories are actually a list.
     // We are just going to use whatever the first one is for now
     if (api.categories && groupBy in api.categories) {
@@ -42,7 +42,7 @@ export function groupByCategory(
  */
 export function removeRamlLinks(apis: RestApi[]): RestApi[] {
   const apiCopy = _.cloneDeep(apis);
-  apiCopy.forEach(apiEntry => {
+  apiCopy.forEach((apiEntry) => {
     delete apiEntry.fatRaml.externalLink;
   });
   return apiCopy;

--- a/src/download/index.test.ts
+++ b/src/download/index.test.ts
@@ -19,7 +19,7 @@ const assetSearchResults = require("../../testResources/download/resources/asset
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const asset = require("../../testResources/download/resources/getAsset");
 // Use a shorter URL for better readability
-asset.files.find(file => file.classifier === "fat-raml").externalLink =
+asset.files.find((file) => file.classifier === "fat-raml").externalLink =
   "https://short.url/raml.zip";
 
 const createZip = (): NodeJS.ReadableStream =>
@@ -40,7 +40,7 @@ const API_CONFIG = {
         "CC API Visibility": ["External"],
         "CC Version Status": ["Beta"],
         "CC API Family": ["Customer"],
-        "API layer": ["Process"]
+        "API layer": ["Process"],
       },
       fatRaml: {
         classifier: "fat-raml",
@@ -48,10 +48,10 @@ const API_CONFIG = {
         createdDate: "2020-02-05T21:26:01.199Z",
         md5: "87b3ad2b2aa17639b52f0cc83c5a8d40",
         sha1: "f2b9b2de50b7250616e2eea8843735b57235c22b",
-        mainFile: "shopper-customers.raml"
-      }
-    }
-  ]
+        mainFile: "shopper-customers.raml",
+      },
+    },
+  ],
 };
 const API_CONFIG_JSON = JSON.stringify(API_CONFIG);
 
@@ -62,21 +62,21 @@ const API_CONFIG_JSON = JSON.stringify(API_CONFIG);
  */
 function setup({
   search = "",
-  version = "0.0.1"
+  version = "0.0.1",
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } = {}): any {
   return (
     test
       .env({ ANYPOINT_USERNAME: "user", ANYPOINT_PASSWORD: "pass" })
       // Intercept getBearer request
-      .nock("https://anypoint.mulesoft.com", scope =>
+      .nock("https://anypoint.mulesoft.com", (scope) =>
         scope
           .post("/accounts/login", { username: "user", password: "pass" })
           // eslint-disable-next-line @typescript-eslint/camelcase
           .reply(200, { access_token: "AUTH_TOKEN" })
       )
       // Intercept searchExchange request
-      .nock("https://anypoint.mulesoft.com/exchange/api/v2", scope =>
+      .nock("https://anypoint.mulesoft.com/exchange/api/v2", (scope) =>
         scope
           .get(`/assets?search=${encodeURIComponent(search)}&types=rest-api`)
           .reply(200, [assetSearchResults[0]])
@@ -84,7 +84,7 @@ function setup({
       // Intercept search requests
       .nock(
         "https://anypoint.mulesoft.com/exchange/api/v2/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        scope =>
+        (scope) =>
           scope
             .get("/shop-products-categories-api-v1")
             .reply(200, asset)
@@ -92,7 +92,7 @@ function setup({
             .reply(200, asset)
       )
       // Intercept downloadRestApis request
-      .nock("https://short.url", scope =>
+      .nock("https://short.url", (scope) =>
         scope.get("/raml.zip").reply(200, createZip())
       )
   );
@@ -144,7 +144,7 @@ describe("Download Command", () => {
       DownloadCommand.run([
         "--group-by=category",
         "--group-by",
-        "CC API Family"
+        "CC API Family",
       ])
     )
     .it("accepts a configurable category for grouping APIs");
@@ -159,7 +159,7 @@ describe("Download Command", () => {
         .with.deep.contents([
           "api-config.json",
           "shopper-customers",
-          "shopper-customers/file.raml"
+          "shopper-customers/file.raml",
         ]);
     });
 
@@ -168,7 +168,7 @@ describe("Download Command", () => {
       DownloadCommand.run([
         `--dest=${tmpOtherDir}`,
         "--group-by",
-        "CC API Family"
+        "CC API Family",
       ])
     )
     .it("accepts a configurable target directory (absolute)", () => {
@@ -177,7 +177,7 @@ describe("Download Command", () => {
         .with.deep.contents([
           "api-config.json",
           "shopper-customers",
-          "shopper-customers/file.raml"
+          "shopper-customers/file.raml",
         ]);
     });
 
@@ -186,7 +186,7 @@ describe("Download Command", () => {
       DownloadCommand.run([
         "--config-file=test-file.json",
         "--group-by",
-        "CC API Family"
+        "CC API Family",
       ])
     )
     .it("accepts a configurable config file name", () => {
@@ -200,7 +200,7 @@ describe("Download Command", () => {
       DownloadCommand.run([
         `--config-file=/path/to/api-config.json`,
         "--group-by",
-        "CC API Family"
+        "CC API Family",
       ])
     )
     .exit(2)
@@ -214,7 +214,7 @@ describe("Download Command", () => {
   test
     .env({
       ANYPOINT_USERNAME: undefined,
-      ANYPOINT_PASSWORD: undefined
+      ANYPOINT_PASSWORD: undefined,
     })
     .do(() => DownloadCommand.run(["--group-by", "CC API Family"]))
     .exit(2)

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -21,43 +21,43 @@ export class DownloadCommand extends Command {
       char: "s",
       description: "Search query to filter results from Anypoint Exchange",
       env: "ANYPOINT_SEARCH",
-      default: ""
+      default: "",
     }),
     deployment: flags.string({
       char: "D",
       description: "Deployment status to filter results from Anypoint Exchange",
       env: "ANYPOINT_DEPLOYMENT",
-      default: "." // RegExp to match any non-empty string
+      default: ".", // RegExp to match any non-empty string
     }),
     "deployment-regex-flags": flags.string({
       description: "RegExp flags to specify for advanced deployment matching",
-      dependsOn: ["deployment"]
+      dependsOn: ["deployment"],
     }),
     dest: flags.string({
       char: "d",
       description: "Directory to download APIs into",
       env: "ANYPOINT_DOWNLOAD_DEST",
-      default: "apis"
+      default: "apis",
     }),
     "group-by": flags.string({
       char: "g",
       description: "Category to use to group APIs together",
       env: "ANYPOINT_GROUP_BY",
-      required: true
+      required: true,
     }),
     "config-file": flags.string({
       char: "c",
       description: "Name of the target file to save the API config",
       env: "ANYPOINT_CONFIG_FILE",
-      default: "api-config.json"
-    })
+      default: "api-config.json",
+    }),
   };
   async run(): Promise<void> {
     if (!process.env.ANYPOINT_USERNAME || !process.env.ANYPOINT_PASSWORD) {
       this.error(
         "Environment variables ANYPOINT_USERNAME and ANYPOINT_PASSWORD must be set to download files.",
         {
-          exit: 2
+          exit: 2,
         }
       );
     }

--- a/src/generate/api.ts
+++ b/src/generate/api.ts
@@ -9,7 +9,7 @@ import { model } from "amf-client-js";
 import {
   resolveApiModel,
   parseRamlFile,
-  getAllDataTypes
+  getAllDataTypes,
 } from "../common/parser";
 
 import { Name } from "./name";

--- a/src/generate/apiCollection.test.ts
+++ b/src/generate/apiCollection.test.ts
@@ -32,7 +32,7 @@ describe("Test ApiCollection class init", () => {
 
   it("creates an instance from a valid raml file", async () => {
     const collection = await ApiCollection.init({
-      "Group One": [validRamlFile]
+      "Group One": [validRamlFile],
     });
     expect(collection.get("Group One")).to.not.be.empty;
     expect(collection.get("Group One")[0].model).to.not.be.empty;
@@ -42,24 +42,18 @@ describe("Test ApiCollection class init", () => {
 
   it("creates an instance from two valid raml files in one group", async () => {
     const collection = await ApiCollection.init({
-      "Group One": [validRamlFile, validRamlFile]
+      "Group One": [validRamlFile, validRamlFile],
     });
-    expect(collection.get("Group One"))
-      .to.be.an("array")
-      .with.lengthOf(2);
+    expect(collection.get("Group One")).to.be.an("array").with.lengthOf(2);
   });
 
   it("creates an instance from two valid raml files in two groups", async () => {
     const collection = await ApiCollection.init({
       "Group One": [validRamlFile],
-      "Group Two": [validRamlFile]
+      "Group Two": [validRamlFile],
     });
-    expect(collection.get("Group One"))
-      .to.be.an("array")
-      .with.lengthOf(1);
-    expect(collection.get("Group Two"))
-      .to.be.an("array")
-      .with.lengthOf(1);
+    expect(collection.get("Group One")).to.be.an("array").with.lengthOf(1);
+    expect(collection.get("Group Two")).to.be.an("array").with.lengthOf(1);
   });
 
   it("rejects from an invalid raml file", () => {

--- a/src/generate/apiCollection.ts
+++ b/src/generate/apiCollection.ts
@@ -36,6 +36,6 @@ export class ApiCollection extends Array<ApiGroup> {
    * @param name - Name of the API group to return from the collection
    */
   get(name: string): ApiGroup {
-    return this.find(g => g.name.original === name);
+    return this.find((g) => g.name.original === name);
   }
 }

--- a/src/generate/apiGroup.ts
+++ b/src/generate/apiGroup.ts
@@ -28,7 +28,7 @@ export class ApiGroup extends Array<Api> {
    */
   static async init(apiSpecFilePaths: string[], name = ""): Promise<ApiGroup> {
     return new ApiGroup(
-      await Promise.all(apiSpecFilePaths.map(p => Api.init(p, name))),
+      await Promise.all(apiSpecFilePaths.map((p) => Api.init(p, name))),
       name
     );
   }
@@ -39,6 +39,6 @@ export class ApiGroup extends Array<Api> {
    * @param name - Name of the API to return from the collection
    */
   get(name: string): Api {
-    return this.find(a => a.name.original === name);
+    return this.find((a) => a.name.original === name);
   }
 }

--- a/src/generate/handlebarsAmfHelpers.test.ts
+++ b/src/generate/handlebarsAmfHelpers.test.ts
@@ -10,7 +10,7 @@ import {
   isAdditionalPropertiesAllowed,
   isOptionalProperty,
   isRequiredProperty,
-  isTypeDefinition
+  isTypeDefinition,
 } from "./handlebarsAmfHelpers";
 import { verifyProperties } from "../../testResources/generate/handlebarsAmfHelpersTestUtils";
 

--- a/src/generate/handlebarsAmfHelpers.ts
+++ b/src/generate/handlebarsAmfHelpers.ts
@@ -14,7 +14,7 @@ import {
   getValue,
   DEFAULT_DATA_TYPE,
   ARRAY_DATA_TYPE,
-  OBJECT_DATA_TYPE
+  OBJECT_DATA_TYPE,
 } from "./utils";
 
 import { model } from "amf-client-js";
@@ -63,7 +63,7 @@ export const getReturnTypeFromOperation = (
   const okResponses = getResponsesFromPayload(operation);
   const dataTypes: string[] = [];
 
-  okResponses.forEach(res => {
+  okResponses.forEach((res) => {
     if (res.payloads.length > 0) {
       dataTypes.push(getTypeFromPayload(res.payloads[0]));
     } else {
@@ -144,7 +144,7 @@ export const getPayloadTypeFromRequest = (
 export const getProperties = (
   node: model.domain.NodeShape | undefined | null
 ): model.domain.PropertyShape[] => {
-  return getFilteredProperties(node, propertyName => {
+  return getFilteredProperties(node, (propertyName) => {
     return !/^([/^]).*.$/.test(propertyName);
   });
 };

--- a/src/generate/handlebarsAmfHelpersGetType.test.ts
+++ b/src/generate/handlebarsAmfHelpersGetType.test.ts
@@ -8,7 +8,7 @@ import {
   getTypeFromParameter,
   getTypeFromProperty,
   getPayloadTypeFromRequest,
-  getReturnTypeFromOperation
+  getReturnTypeFromOperation,
 } from "./handlebarsAmfHelpers";
 import { ARRAY_DATA_TYPE, OBJECT_DATA_TYPE } from "./utils";
 import {
@@ -17,7 +17,7 @@ import {
   getLinkedType,
   getObjectType,
   getRequestPayloadModel,
-  getScalarType
+  getScalarType,
 } from "../../testResources/generate/handlebarsAmfHelpersTestUtils";
 
 import { model, AMF } from "amf-client-js";
@@ -265,9 +265,7 @@ describe("HandlebarsAmfHelpers get type helper functions", () => {
       shape.withItems(arrItem);
 
       expect(getPayloadTypeFromRequest(getRequestPayloadModel(shape))).to.equal(
-        ARRAY_DATA_TYPE.concat("<")
-          .concat(typeName)
-          .concat(">")
+        ARRAY_DATA_TYPE.concat("<").concat(typeName).concat(">")
       );
     });
   });

--- a/src/generate/template.test.ts
+++ b/src/generate/template.test.ts
@@ -81,9 +81,7 @@ describe("Render template", () => {
     const data = { name: "Test rendering" };
     const dest = "/tmp/rendered_testing.ts";
     await template.render(data, dest);
-    expect(dest)
-      .to.be.a.file()
-      .with.content(data.name);
+    expect(dest).to.be.a.file().with.content(data.name);
   });
 
   it("renders template with default handlebars environment", async () => {
@@ -98,9 +96,7 @@ describe("Render template", () => {
     await template.render(data, renderedFile.name);
 
     //verify the rendered content
-    expect(renderedFile.name)
-      .to.be.a.file()
-      .with.content(data.name);
+    expect(renderedFile.name).to.be.a.file().with.content(data.name);
   });
 
   it("renders template with the given handlebars environment", async () => {
@@ -110,7 +106,7 @@ describe("Render template", () => {
     writeFileSync(tmpFile.name, templateContent);
     //Creates an isolated Handlebars environment.
     const customHb = Handlebars.create();
-    customHb.registerHelper("changeName", name => {
+    customHb.registerHelper("changeName", (name) => {
       return `Testing custom handlebars - ${name}`;
     });
     const template = new Template(tmpFile.name, customHb);

--- a/src/generate/template.ts
+++ b/src/generate/template.ts
@@ -49,7 +49,7 @@ export class Template {
         //Parts of the AMF model use prototype properties and methods, we need to make those available to Handlebars
         this.handlebars.compile(this.content)(context, {
           allowProtoPropertiesByDefault: true,
-          allowProtoMethodsByDefault: true
+          allowProtoMethodsByDefault: true,
         })
       );
     } catch (error) {

--- a/src/generate/utils.ts
+++ b/src/generate/utils.ts
@@ -15,7 +15,7 @@ export const PRIMITIVE_DATA_TYPE_MAP = {
   "http://www.w3.org/2001/XMLSchema#integer": "number",
   "http://www.w3.org/2001/XMLSchema#double": "number",
   "http://www.w3.org/2001/XMLSchema#float": "number",
-  "http://www.w3.org/2001/XMLSchema#boolean": "boolean"
+  "http://www.w3.org/2001/XMLSchema#boolean": "boolean",
 };
 
 /**
@@ -50,7 +50,7 @@ export const getTypeFromPayload = (payload: model.domain.Payload): string => {
   }
   if ((payload.schema as model.domain.UnionShape).anyOf !== undefined) {
     const union: string[] = [];
-    (payload.schema as model.domain.UnionShape).anyOf.forEach(element => {
+    (payload.schema as model.domain.UnionShape).anyOf.forEach((element) => {
       union.push(element.name.value());
     });
     return union.join(" | ");
@@ -208,9 +208,7 @@ const getArrayType = (arrayShape: model.domain.ArrayShape): string => {
     if (arrayShape.inherits != null && arrayShape.inherits.length > 0)
       arrItem = (arrayShape.inherits[0] as model.domain.ArrayShape).items;
   }
-  return ARRAY_DATA_TYPE.concat("<")
-    .concat(getDataType(arrItem))
-    .concat(">");
+  return ARRAY_DATA_TYPE.concat("<").concat(getDataType(arrItem)).concat(">");
 };
 
 /**
@@ -265,7 +263,7 @@ export const getFilteredProperties = (
 
   while (node != null) {
     if (node.properties != null && node.properties.length > 0) {
-      node.properties.forEach(prop => {
+      node.properties.forEach((prop) => {
         if (prop != null) {
           const propName = getValue(prop.name);
           //ignore duplicate props

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ export { model } from "amf-client-js";
 
 export * from "./generate";
 
-// eslint-disable-next-line prettier/prettier
 export * as diff from "./diff";
 
 export {
@@ -23,5 +22,5 @@ export {
   getApiName,
   getNormalizedName,
   parseRamlFile,
-  resolveApiModel
+  resolveApiModel,
 } from "./common/parser";

--- a/src/lint/index.test.ts
+++ b/src/lint/index.test.ts
@@ -11,7 +11,7 @@ import { expect, test } from "@oclif/test";
 import {
   getSingleValidFile,
   getSingleInvalidFile,
-  getSlightlyInvalidFile
+  getSlightlyInvalidFile,
 } from "../../testResources/testUtils";
 import { rename } from "fs-extra";
 
@@ -26,14 +26,14 @@ describe("raml-toolkit cli", () => {
     .stdout()
     .do(() => cmd.run(["--version"]))
     .exit(0)
-    .it("checks that the version string starts with the app name", ctx => {
+    .it("checks that the version string starts with the app name", (ctx) => {
       expect(ctx.stdout).to.contain("@commerce-apps/raml-toolkit");
     });
 
   test
     .stdout()
     .stderr()
-    .do(function() {
+    .do(function () {
       return cmd.run([getSingleValidFile()]);
     })
     .exit(2)
@@ -42,14 +42,14 @@ describe("raml-toolkit cli", () => {
   test
     .stdout()
     .do(() => cmd.run(["--profile", MERCURY_PROFILE, getSingleValidFile()]))
-    .it("validates a single valid file and reports that it conforms", ctx => {
+    .it("validates a single valid file and reports that it conforms", (ctx) => {
       expect(ctx.stdout).to.contain(successString);
     });
 
   test
     .stdout()
     .do(() => cmd.run(["--profile", MERCURY_PROFILE, getSingleValidFile()]))
-    .it("validates a single valid file and reports that it conforms", ctx => {
+    .it("validates a single valid file and reports that it conforms", (ctx) => {
       expect(ctx.stdout).to.contain(successString);
       expect(ctx.stdout).to.contain("Number of hidden warnings:");
     });
@@ -61,12 +61,12 @@ describe("raml-toolkit cli", () => {
         "--profile",
         MERCURY_PROFILE,
         getSingleValidFile(),
-        "--warnings"
+        "--warnings",
       ])
     )
     .it(
       "validates a single valid file and reports that it conforms, without hidden warnings",
-      ctx => {
+      (ctx) => {
         expect(ctx.stdout).to.contain(successString);
         expect(ctx.stdout).to.not.contain("Number of hidden warnings:");
       }
@@ -87,7 +87,7 @@ describe("raml-toolkit cli", () => {
     .it(
       "validates a single valid file with a space in the name" +
         " and reports that it conforms",
-      ctx => {
+      (ctx) => {
         expect(ctx.stdout).to.contain(successString);
       }
     );
@@ -113,10 +113,10 @@ describe("raml-toolkit cli", () => {
         "--profile",
         MERCURY_PROFILE,
         getSingleValidFile(),
-        getSingleValidFile()
+        getSingleValidFile(),
       ])
     )
-    .it("validates two valid files and reports that it conforms", ctx => {
+    .it("validates two valid files and reports that it conforms", (ctx) => {
       expect(ctx.stdout).to.contain(successString);
     });
 
@@ -128,7 +128,7 @@ describe("raml-toolkit cli", () => {
         "--profile",
         MERCURY_PROFILE,
         getSingleValidFile(),
-        getSingleInvalidFile()
+        getSingleInvalidFile(),
       ])
     )
     .exit(1)
@@ -142,7 +142,7 @@ describe("raml-toolkit cli", () => {
         "--profile",
         MERCURY_PROFILE,
         getSingleValidFile(),
-        getSlightlyInvalidFile()
+        getSlightlyInvalidFile(),
       ])
     )
     .exit(1)
@@ -159,7 +159,7 @@ describe("raml-toolkit cli", () => {
     .stdout()
     .do(() => cmd.run(["--help"]))
     .exit(0)
-    .it("does not include TypeScript files in profile", ctx => {
+    .it("does not include TypeScript files in profile", (ctx) => {
       expect(ctx.stdout).to.not.include(".ts");
     });
 });

--- a/src/lint/index.ts
+++ b/src/lint/index.ts
@@ -18,8 +18,8 @@ export const profilePath = path.join(
 
 const profiles = fs
   .readdirSync(profilePath)
-  .filter(file => path.extname(file).toLowerCase() === ".raml")
-  .map(file => file.slice(0, -5)); // Strip .raml extension from file name
+  .filter((file) => path.extname(file).toLowerCase() === ".raml")
+  .map((file) => file.slice(0, -5)); // Strip .raml extension from file name
 
 export default class LintCommand extends Command {
   static description = `A linting tool for raml for Commerce Cloud and beyond`;
@@ -31,21 +31,21 @@ export default class LintCommand extends Command {
       char: "p",
       options: profiles,
       description: "Profile to apply",
-      required: true
+      required: true,
     }),
     // Add --warnings flag to show warnings
     warnings: flags.boolean({
       char: "w",
       default: false,
-      description: "Show all the warnings"
-    })
+      description: "Show all the warnings",
+    }),
   };
 
   static args = [
     {
       name: "filename",
-      description: "One or more RAML files to lint"
-    }
+      description: "One or more RAML files to lint",
+    },
   ];
   // Allow a variable length list of files
   static strict = false;
@@ -65,7 +65,7 @@ export default class LintCommand extends Command {
     await AMF.init();
     for (const arg of argv) {
       promises.push(
-        validateFile(arg, flags.profile).then(results => {
+        validateFile(arg, flags.profile).then((results) => {
           if (results.conforms === false) {
             exitCode += 1;
           }
@@ -74,14 +74,14 @@ export default class LintCommand extends Command {
       );
     }
 
-    await Promise.all(promises).catch(e => {
+    await Promise.all(promises).catch((e) => {
       console.error(e.message);
       exitCode += 1;
     });
 
     if (exitCode !== 0) {
       this.error(`Validation for ${exitCode} file(s) failed.`, {
-        exit: exitCode
+        exit: exitCode,
       });
     }
   }

--- a/src/lint/lint.test.ts
+++ b/src/lint/lint.test.ts
@@ -13,7 +13,7 @@ import { printResults, validateFile, validateCustom } from "./lint";
 import {
   getHappySpec,
   renderSpecAsFile,
-  getSingleInvalidFile
+  getSingleInvalidFile,
 } from "../../testResources/testUtils";
 
 const PROFILE = "mercury";

--- a/testResources/download/resources/restApiResponseObjects.ts
+++ b/testResources/download/resources/restApiResponseObjects.ts
@@ -21,7 +21,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       "API layer": ["Process"],
       "CC API Family": ["Product"],
       "CC Version Status": ["Beta"],
-      "CC API Visibility": ["External"]
+      "CC API Visibility": ["External"],
     },
     fatRaml: {
       classifier: "fat-raml",
@@ -31,8 +31,8 @@ export const searchAssetApiResultObject: RestApi[] = [
       createdDate: "2019-12-16T04:39:24.474Z",
       md5: "6dfef81b5b25ad396d342f438f7060e7",
       sha1: "9133f1f4bf53664c0329b64a0b2010abfef18346",
-      mainFile: "shop-products-categories-api-v1.raml"
-    }
+      mainFile: "shop-products-categories-api-v1.raml",
+    },
   },
   {
     id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/data-catalogs-api-v1/0.0.1",
@@ -47,7 +47,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       "API layer": ["Process"],
       "CC API Family": ["Product"],
       "CC Version Status": ["Beta"],
-      "CC API Visibility": ["External"]
+      "CC API Visibility": ["External"],
     },
     fatRaml: {
       classifier: "fat-raml",
@@ -57,8 +57,8 @@ export const searchAssetApiResultObject: RestApi[] = [
       createdDate: "2019-12-16T04:48:18.289Z",
       md5: "5b394c2017c7151b3290f9dc3b7bf351",
       sha1: "549d6e977697ab7a35a815683a524faf889a7591",
-      mainFile: "data-catalogs-api-v1.raml"
-    }
+      mainFile: "data-catalogs-api-v1.raml",
+    },
   },
   {
     id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-search-api/1.0.0",
@@ -73,7 +73,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       "API layer": ["Process"],
       "CC API Family": ["Search"],
       "CC Version Status": ["Beta"],
-      "CC API Visibility": ["External"]
+      "CC API Visibility": ["External"],
     },
     fatRaml: {
       classifier: "fat-raml",
@@ -83,8 +83,8 @@ export const searchAssetApiResultObject: RestApi[] = [
       createdDate: "2019-12-19T12:51:48.749Z",
       md5: "d86c749c24fadf4c68244481b25156eb",
       sha1: "e51f567ce47d35dee152edf8c3a9405fa53736d6",
-      mainFile: "shopper-search-api.raml"
-    }
+      mainFile: "shopper-search-api.raml",
+    },
   },
   {
     id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/data-products-api-v1/0.0.1",
@@ -99,7 +99,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       "API layer": ["Process"],
       "CC API Family": ["Product"],
       "CC Version Status": ["Beta"],
-      "CC API Visibility": ["External"]
+      "CC API Visibility": ["External"],
     },
     fatRaml: {
       classifier: "fat-raml",
@@ -109,8 +109,8 @@ export const searchAssetApiResultObject: RestApi[] = [
       createdDate: "2019-12-16T04:44:17.727Z",
       md5: "f0d5c07e79be7fa893306c26020f576f",
       sha1: "ab6cdadbae40b0aa5b8308dd94919ff2b2433ca0",
-      mainFile: "data-products-api-v1.raml"
-    }
+      mainFile: "data-products-api-v1.raml",
+    },
   },
   {
     id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/source-code-groups/1.0.0",
@@ -126,7 +126,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       "API layer": ["System"],
       "CC API Family": ["Pricing"],
       "CC Version Status": ["Beta"],
-      "CC API Visibility": ["External"]
+      "CC API Visibility": ["External"],
     },
     fatRaml: {
       classifier: "fat-raml",
@@ -136,8 +136,8 @@ export const searchAssetApiResultObject: RestApi[] = [
       createdDate: "2019-12-19T19:46:28.038Z",
       md5: "5f7d3f19bb23e8cae787aec794b1b4de",
       sha1: "172267d55d2d85d9f093206e2f12328130eb6481",
-      mainFile: "source-code-groups.raml"
-    }
+      mainFile: "source-code-groups.raml",
+    },
   },
   {
     id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shop-customers-api-v1/0.0.1",
@@ -152,7 +152,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       "API layer": ["System"],
       "CC API Family": ["Customer"],
       "CC Version Status": ["Beta"],
-      "CC API Visibility": ["External"]
+      "CC API Visibility": ["External"],
     },
     fatRaml: {
       classifier: "fat-raml",
@@ -162,7 +162,7 @@ export const searchAssetApiResultObject: RestApi[] = [
       createdDate: "2019-12-16T04:33:38.985Z",
       md5: "3c0c13631a8846f8b62272aaaac4f1ac",
       sha1: "e7fba62b4cdec87e6cbcf32cd4b232c030dc766b",
-      mainFile: "shop-customers-api-v1.raml"
-    }
-  }
+      mainFile: "shop-customers-api-v1.raml",
+    },
+  },
 ];

--- a/testResources/generate/handlebarsAmfHelpersTestUtils.ts
+++ b/testResources/generate/handlebarsAmfHelpersTestUtils.ts
@@ -65,10 +65,10 @@ export const verifyProperties = (
 ): void => {
   expect(actualProps).to.be.length(expectedProps.length);
   const expectedPropNames: Set<string> = new Set();
-  expectedProps.forEach(prop => {
+  expectedProps.forEach((prop) => {
     expectedPropNames.add(prop.name.value());
   });
-  actualProps.forEach(prop => {
+  actualProps.forEach((prop) => {
     expect(expectedPropNames.has(prop.name.value())).to.be.true;
   });
 };

--- a/testResources/testUtils.ts
+++ b/testResources/testUtils.ts
@@ -56,7 +56,7 @@ export function breaksTheseRules(
 ): void {
   assert.equal(result.conforms, false, result.toString());
   assert.sameMembers(
-    result.results.map(r => r.validationId),
+    result.results.map((r) => r.validationId),
     rules,
     result.toString()
   );


### PR DESCRIPTION
**Some of the main changes**
- Supports new typescript syntax added in 3.8
- Dropped support for node versions older than 10
- Change default value for trailingComma to es5

For more details:
https://prettier.io/blog/2020/03/21/2.0.0.html
https://github.com/prettier/prettier/blob/master/CHANGELOG.md