### PR TITLE
(Final Review) Added lint rule ensuring all tests eventually return, and fixing broken tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fintechstudios/eslint-plugin-chai-as-promised": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fintechstudios/eslint-plugin-chai-as-promised/-/eslint-plugin-chai-as-promised-3.0.2.tgz",
+      "integrity": "sha512-mHavP4gRhtpLwpKkoGZ3GHnKhyeCc7CeSXWLbgehEKGQNRD97ye8jlrwda/Xfc74Xn7MtLG4CJgA3fTIK6bveQ==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -493,7 +499,7 @@
     },
     "@oclif/dev-cli": {
       "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.22.2.tgz",
+      "resolved": false,
       "integrity": "sha512-c7633R37RxrQIpwqPKxjNRm6/jb1yuG8fd16hmNz9Nw+/MUhEtQtKHSCe9ScH8n5M06l6LEo4ldk9LEGtpaWwA==",
       "dev": true,
       "requires": {
@@ -607,7 +613,7 @@
     },
     "@oclif/test": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@oclif/test/-/test-1.2.5.tgz",
+      "resolved": false,
       "integrity": "sha512-8Y+Ix4A3Zhm87aL0ldVonDK7vFWyLfnFHzP3goYaLyIeh/60KL37lMxfmbp/kBN6/Y0Ru17iR1pdDi/hTDClLQ==",
       "dev": true,
       "requires": {
@@ -948,7 +954,7 @@
     },
     "@types/chai-as-promised": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "resolved": false,
       "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
       "dev": true,
       "requires": {
@@ -989,7 +995,7 @@
     },
     "@types/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+      "resolved": false,
       "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
       "dev": true,
       "requires": {
@@ -1025,7 +1031,7 @@
     },
     "@types/jszip": {
       "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.1.7.tgz",
+      "resolved": false,
       "integrity": "sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==",
       "dev": true,
       "requires": {
@@ -1057,7 +1063,7 @@
     },
     "@types/node-fetch": {
       "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "resolved": false,
       "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
       "dev": true,
       "requires": {
@@ -1087,7 +1093,7 @@
     },
     "@types/tmp": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
+      "resolved": false,
       "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
       "dev": true
     },
@@ -1101,7 +1107,7 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
+      "resolved": false,
       "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
       "dev": true,
       "requires": {
@@ -1125,7 +1131,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
+      "resolved": false,
       "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
       "dev": true,
       "requires": {
@@ -1858,7 +1864,7 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "resolved": false,
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
@@ -1872,7 +1878,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "resolved": false,
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
@@ -2618,7 +2624,7 @@
     },
     "depcheck": {
       "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.9.2.tgz",
+      "resolved": false,
       "integrity": "sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==",
       "dev": true,
       "requires": {
@@ -2884,7 +2890,7 @@
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "resolved": false,
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -3007,7 +3013,7 @@
     },
     "eslint-config-prettier": {
       "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "resolved": false,
       "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
@@ -3016,13 +3022,13 @@
     },
     "eslint-plugin-header": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
+      "resolved": false,
       "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==",
       "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "resolved": false,
       "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
@@ -3463,6 +3469,12 @@
         "write": "1.0.3"
       },
       "dependencies": {
+        "flatted": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+          "dev": true
+        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -3475,9 +3487,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.0.4.tgz",
+      "integrity": "sha512-4gZhsMc26tSiMgQ+0gRN818ST2KCkX/4EvqocCkE1+SRb7mapNk4KLSP+XAj02jc8rxuyD3DrmI3a0BQ/TNOpg==",
       "dev": true
     },
     "fn-name": {
@@ -4951,7 +4963,7 @@
     },
     "lint-staged": {
       "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.1.tgz",
+      "resolved": false,
       "integrity": "sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==",
       "dev": true,
       "requires": {
@@ -5640,7 +5652,7 @@
     },
     "mocha": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
+      "resolved": false,
       "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
       "dev": true,
       "requires": {
@@ -6047,7 +6059,7 @@
     },
     "nock": {
       "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "resolved": false,
       "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
       "dev": true,
       "requires": {
@@ -6148,7 +6160,7 @@
     },
     "nyc": {
       "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.1.tgz",
+      "resolved": false,
       "integrity": "sha512-n0MBXYBYRqa67IVt62qW1r/d9UH/Qtr7SF1w/nQLJ9KxvWF6b2xCHImRAixHN9tnMMYHC2P14uo6KddNGwMgGg==",
       "dev": true,
       "requires": {
@@ -7152,7 +7164,7 @@
     },
     "sinon": {
       "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "resolved": false,
       "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -165,7 +165,6 @@
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-prettier": "^3.1.0",
-    "flatted": "^3.0.4",
     "jszip": "^3.2.2",
     "lint-staged": "^8.1.0",
     "mocha": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,14 @@
     },
     "plugins": [
       "@typescript-eslint",
-      "header"
+      "header",
+      "@fintechstudios/eslint-plugin-chai-as-promised"
     ],
     "extends": [
       "plugin:@typescript-eslint/recommended",
       "prettier/@typescript-eslint",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:@fintechstudios/chai-as-promised/recommended"
     ],
     "rules": {
       "max-lines": [
@@ -141,6 +143,7 @@
     "unzipper": "^0.10.11"
   },
   "devDependencies": {
+    "@fintechstudios/eslint-plugin-chai-as-promised": "^3.0.2",
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/parser": "^3.8.5",
     "@oclif/test": "^1.2.5",
@@ -162,6 +165,7 @@
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "flatted": "^3.0.4",
     "jszip": "^3.2.2",
     "lint-staged": "^8.1.0",
     "mocha": "^7.0.1",

--- a/src/common/parser.test.ts
+++ b/src/common/parser.test.ts
@@ -33,11 +33,13 @@ before(() => {
 });
 
 describe("Test RAML file", () => {
-  it("Test invalid RAML file", () =>
-    expect(parseRamlFile(invalidRamlFile)).to.eventually.be.rejected);
+  it("Test invalid RAML file", () => {
+    return expect(parseRamlFile(invalidRamlFile)).to.eventually.be.rejected;
+  });
 
-  it("Test valid RAML file", () =>
-    expect(parseRamlFile(validRamlFile)).to.eventually.not.be.empty);
+  it("Test valid RAML file", () => {
+    return expect(parseRamlFile(validRamlFile)).to.eventually.not.be.empty;
+  });
 });
 
 describe("Get Data types", () => {

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -282,7 +282,7 @@ describe("getAsset", () => {
       .get("/8888888/test-get-asset")
       .reply(200, { data: "json response" });
 
-    expect(
+    return expect(
       getAsset("AUTH_TOKEN", "8888888/test-get-asset")
     ).to.eventually.deep.equal({ data: "json response" });
   });
@@ -292,8 +292,8 @@ describe("getAsset", () => {
       .get("/8888888/get-asset-404")
       .reply(404, "Not Found");
 
-    expect(getAsset("AUTH_TOKEN", "8888888/get-asset-404")).to.eventually.be
-      .undefined;
+    return expect(getAsset("AUTH_TOKEN", "8888888/get-asset-404")).to.eventually
+      .be.undefined;
   });
 });
 
@@ -331,7 +331,7 @@ describe("search", () => {
         Authorization: "Bearer AUTH_TOKEN"
       }
     })
-      .get("/assets?search=searchString")
+      .get("/assets?search=searchString&types=rest-api")
       .reply(200, [assetSearchResults[0]]);
   });
 
@@ -342,7 +342,9 @@ describe("search", () => {
       .get("/shop-products-categories-api-v1/0.0.1")
       .reply(200, getAssetWithVersion);
 
-    expect(search("searchString", /production/i)).to.eventually.deep.equal([
+    return expect(
+      search("searchString", /production/i)
+    ).to.eventually.deep.equal([
       {
         id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1",
         name: "Shopper Customers",
@@ -374,7 +376,9 @@ describe("search", () => {
 
   it("works when an asset does not exist", () => {
     scope.get("/shop-products-categories-api-v1").reply(404, "Not Found");
-    expect(search("searchString", /unused regex/)).to.eventually.deep.equal([
+    return expect(
+      search("searchString", /unused regex/)
+    ).to.eventually.deep.equal([
       {
         id: null,
         name: "Shopper Products",
@@ -409,7 +413,7 @@ describe("search", () => {
       .get("/shop-products-categories-api-v1/0.0.7")
       .reply(200, getAssetWithoutVersion);
 
-    expect(
+    return expect(
       search("searchString", /nothing should match/)
     ).to.eventually.deep.equal([
       {
@@ -430,8 +434,7 @@ describe("search", () => {
         fatRaml: {
           classifier: "fat-raml",
           packaging: "zip",
-          externalLink:
-            "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/37bb0c576a8e98746ba998dc42c926007d96229de7566b04d555f0d83f05368a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJTBQMSKYL2HXJA4A%2F20200206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200206T192402Z&X-Amz-Expires=86400&X-Amz-Signature=0345e90e7e437e539b21f8a6d0fab74e711dde1131ccc6419782302dbd337954&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-customers-0.0.7-raml.zip",
+          externalLink: "https://short.url/raml.zip",
           createdDate: "2020-02-05T21:26:01.199Z",
           md5: "87b3ad2b2aa17639b52f0cc83c5a8d40",
           sha1: "f2b9b2de50b7250616e2eea8843735b57235c22b",

--- a/src/lint/lint.test.ts
+++ b/src/lint/lint.test.ts
@@ -72,7 +72,7 @@ describe("#printResults", () => {
 describe("#validateCustom", () => {
   let testModel: model.document.Document;
 
-  beforeEach( async () => {
+  beforeEach(async () => {
     await AMF.init();
     testModel = new model.document.Document();
   });

--- a/src/lint/lint.test.ts
+++ b/src/lint/lint.test.ts
@@ -8,7 +8,7 @@
 import { expect, default as chai } from "chai";
 import sinon from "sinon";
 import chaiAsPromised from "chai-as-promised";
-import { model } from "amf-client-js";
+import { model, AMF } from "amf-client-js";
 import { printResults, validateFile, validateCustom } from "./lint";
 import {
   getHappySpec,
@@ -72,13 +72,17 @@ describe("#printResults", () => {
 describe("#validateCustom", () => {
   let testModel: model.document.Document;
 
-  beforeEach(() => {
+  beforeEach( async () => {
+    await AMF.init();
     testModel = new model.document.Document();
   });
 
   it("missing validation profile", () => {
-    expect(
-      validateCustom(testModel, "file://MISSINGFILE")
-    ).to.be.eventually.rejectedWith("No registered runtime validator");
+    const customProfile = "file://MISSINGFILE";
+    return expect(
+      validateCustom(testModel, customProfile)
+    ).to.be.eventually.rejectedWith(
+      `Custom profile ${customProfile} does not exist`
+    );
   });
 });

--- a/src/lint/lint.test.ts
+++ b/src/lint/lint.test.ts
@@ -85,4 +85,10 @@ describe("#validateCustom", () => {
       `Custom profile ${customProfile} does not exist`
     );
   });
+  it("uses unsupported schema", () => {
+    const customProfile = "uri://MISSINGFILE";
+    return expect(
+      validateCustom(testModel, customProfile)
+    ).to.be.eventually.rejectedWith(`Unsupported`);
+  });
 });

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -24,7 +24,7 @@ export async function validateCustom(
       throw new Error(`Custom profile ${profileFile} does not exist`);
     }
     // An unexpected error was generated, throw a clean version of it.
-    throw new Error(err.Yw);
+    throw new Error(message);
   }
   const report = await Core.validate(amfModel, profileName, MessageStyles.RAML);
   return report;

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -19,7 +19,12 @@ export async function validateCustom(
     profileName = await Core.loadValidationProfile(profileFile);
   } catch (err) {
     // We rethrow to provide a cleaner error message
-    throw new Error(err.vw);
+    const message: string = err.Yw;
+    if (message.includes("no such file or directory")) {
+      throw new Error(`Custom profile ${profileFile} does not exist`);
+    }
+    // An unexpected error was generated, throw a clean version of it.
+    throw new Error(err.Yw);
   }
   const report = await Core.validate(amfModel, profileName, MessageStyles.RAML);
   return report;


### PR DESCRIPTION
W-7879769 : Fix broken tests in raml-toolkit

Some tests which utilized mocha's `eventually` were not waiting for the promise to return before finishing the test.

A lint rule has been added to ensure tests that use `eventually` now return the actual result.
All tests now comply with the linting rule.
Any broken tests have been fixed.