### PR TITLE
Release/20201708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+
+## 0.5.0
+
+* *NEW FEATURE* Added CLI commands to download raml files directly from exchange
+* *NEW FEATURE* Added ability to render templates from an API model 
+* Exports have been reorganized to match associated CLI commands
+* Added additional ignore rules and other enhancements to the difftool to ensure a better signal to noise ratio.
+
 ## 0.4.5
 
 * Added new profile for slas

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "",
   "keywords": [
     "oclif",


### PR DESCRIPTION
* *NEW FEATURE* Added CLI commands to download raml files directly from exchange
* *NEW FEATURE* Added ability to render templates from an API model 
* Exports have been reorganized to match associated CLI commands
* Added additional ignore rules and other enhancements to the difftool to ensure a better signal to noise ratio.