### PR TITLE
npm audit fixes and .snyk updates

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,11 +1,11 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
+version: v1.14.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-AJV-584908:
     - amf-client-js > ajv:
         reason: No remediation path available
-        expires: '2020-08-15T19:23:37.755Z'
+        expires: '2020-10-09T19:50:45.075Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-567746:

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,7 +499,7 @@
     },
     "@oclif/dev-cli": {
       "version": "1.22.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-c7633R37RxrQIpwqPKxjNRm6/jb1yuG8fd16hmNz9Nw+/MUhEtQtKHSCe9ScH8n5M06l6LEo4ldk9LEGtpaWwA==",
       "dev": true,
       "requires": {
@@ -613,7 +613,7 @@
     },
     "@oclif/test": {
       "version": "1.2.5",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-8Y+Ix4A3Zhm87aL0ldVonDK7vFWyLfnFHzP3goYaLyIeh/60KL37lMxfmbp/kBN6/Y0Ru17iR1pdDi/hTDClLQ==",
       "dev": true,
       "requires": {
@@ -954,7 +954,7 @@
     },
     "@types/chai-as-promised": {
       "version": "7.1.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
       "dev": true,
       "requires": {
@@ -995,7 +995,7 @@
     },
     "@types/fs-extra": {
       "version": "8.1.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
       "dev": true,
       "requires": {
@@ -1031,7 +1031,7 @@
     },
     "@types/jszip": {
       "version": "3.1.7",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==",
       "dev": true,
       "requires": {
@@ -1063,7 +1063,7 @@
     },
     "@types/node-fetch": {
       "version": "2.5.5",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
       "dev": true,
       "requires": {
@@ -1107,7 +1107,7 @@
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.27.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
       "dev": true,
       "requires": {
@@ -1131,7 +1131,7 @@
     },
     "@typescript-eslint/parser": {
       "version": "2.27.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
       "dev": true,
       "requires": {
@@ -1556,9 +1556,9 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1733,9 +1733,9 @@
       }
     },
     "buffer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -1864,7 +1864,7 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
@@ -1878,7 +1878,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
@@ -2624,7 +2624,7 @@
     },
     "depcheck": {
       "version": "0.9.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==",
       "dev": true,
       "requires": {
@@ -2890,7 +2890,7 @@
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -3013,7 +3013,7 @@
     },
     "eslint-config-prettier": {
       "version": "6.10.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
@@ -3022,13 +3022,13 @@
     },
     "eslint-plugin-header": {
       "version": "3.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==",
       "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
@@ -4957,7 +4957,7 @@
     },
     "lint-staged": {
       "version": "8.2.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==",
       "dev": true,
       "requires": {
@@ -5331,9 +5331,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -5646,7 +5646,7 @@
     },
     "mocha": {
       "version": "7.1.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
       "dev": true,
       "requires": {
@@ -6053,7 +6053,7 @@
     },
     "nock": {
       "version": "12.0.3",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
       "dev": true,
       "requires": {
@@ -6154,7 +6154,7 @@
     },
     "nyc": {
       "version": "15.0.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-n0MBXYBYRqa67IVt62qW1r/d9UH/Qtr7SF1w/nQLJ9KxvWF6b2xCHImRAixHN9tnMMYHC2P14uo6KddNGwMgGg==",
       "dev": true,
       "requires": {
@@ -7158,7 +7158,7 @@
     },
     "sinon": {
       "version": "9.0.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "js-yaml": "^3.14.0",
     "json-rules-engine": "^5.0.3",
     "jsondiffpatch": "^0.4.1",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "loglevel": "^1.6.8",
     "node-fetch": "^2.6.0",
     "snyk": "^1.355.0",


### PR DESCRIPTION
This PR is part of W-8038871 ticket to utilize the minor deployment tags while downloading the Mercury RAMLs. 

PR Contains: 
- A quick npm audit fix and .snyk updates 

Tests:
- compiles and Builds
- used npm pack to test raml-toolkit manual