### PR TITLE
Refactor directory diff to use api models

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ DESCRIPTION
      Directory mode compares all the files in two directories and determines if there are any differences.
 
   In ruleset and diff-only mode, the arguments must be API specification (RAML) files.
-  In directory mode, the arguments must be directories containing the API files.
+  In directory mode, the arguments must be directories containing API specification (RAML) files.
 
   Exit statuses:
      0 - No breaking changes (ruleset mode) or no differences (diff-only / directory)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ USAGE
   $ raml-toolkit diff BASE NEW
 
 ARGUMENTS
-  BASE  The base API spec file (ruleset / diff-only mode) or configuration (directory mode)
-  NEW   The new API spec file (ruleset / diff-only mode) or configuration (directory mode)
+  BASE  The base API spec file (ruleset / diff-only mode) or directory
+  NEW   The new API spec file (ruleset / diff-only mode) or directory
 
 OPTIONS
   -f, --format=(json|console)                        Format of the output. Defaults to JSON if --out-file is specified,
@@ -71,7 +71,7 @@ DESCRIPTION
      Directory mode compares all the files in two directories and determines if there are any differences.
 
   In ruleset and diff-only mode, the arguments must be API specification (RAML) files.
-  In directory mode, the arguments must be API configuration (JSON) files.
+  In directory mode, the arguments must be directories containing the API files.
 
   Exit statuses:
      0 - No breaking changes (ruleset mode) or no differences (diff-only / directory)

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,7 +499,7 @@
     },
     "@oclif/dev-cli": {
       "version": "1.22.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.22.2.tgz",
       "integrity": "sha512-c7633R37RxrQIpwqPKxjNRm6/jb1yuG8fd16hmNz9Nw+/MUhEtQtKHSCe9ScH8n5M06l6LEo4ldk9LEGtpaWwA==",
       "dev": true,
       "requires": {
@@ -1864,7 +1864,7 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
@@ -1878,7 +1878,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
@@ -2624,7 +2624,7 @@
     },
     "depcheck": {
       "version": "0.9.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.9.2.tgz",
       "integrity": "sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==",
       "dev": true,
       "requires": {
@@ -2890,7 +2890,7 @@
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -3022,7 +3022,7 @@
     },
     "eslint-plugin-header": {
       "version": "3.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
       "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==",
       "dev": true
     },
@@ -4957,7 +4957,7 @@
     },
     "lint-staged": {
       "version": "8.2.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.1.tgz",
       "integrity": "sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==",
       "dev": true,
       "requires": {
@@ -6053,7 +6053,7 @@
     },
     "nock": {
       "version": "12.0.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
       "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
       "dev": true,
       "requires": {

--- a/src/diff/changes/apiCollectionChanges.test.ts
+++ b/src/diff/changes/apiCollectionChanges.test.ts
@@ -13,7 +13,6 @@ import {
 } from "./apiCollectionChanges";
 import { CategorizedChange } from "./categorizedChange";
 import { RuleCategory } from "../ruleCategory";
-import sinon from "sinon";
 
 function buildCategorizedChange(c = RuleCategory.BREAKING): CategorizedChange {
   return new CategorizedChange("r1", "title-changed", c, ["old", "new"]);

--- a/src/diff/changes/apiCollectionChanges.test.ts
+++ b/src/diff/changes/apiCollectionChanges.test.ts
@@ -33,7 +33,7 @@ function buildApiChanges(categories = [[RuleCategory.BREAKING]]): ApiChanges {
 function buildApiCollectionChanges(
   changed?: ApiCollectionChanges["changed"]
 ): ApiCollectionChanges {
-  const changes = new ApiCollectionChanges("baseApiConfig", "newApiConfig");
+  const changes = new ApiCollectionChanges("baseDir", "newDir");
   changes.changed = changed || {};
   return changes;
 }
@@ -43,8 +43,8 @@ describe("Create an instance of ApiCollectionChanges", () => {
     const apiCollectionChanges = buildApiCollectionChanges();
 
     expect(apiCollectionChanges).to.be.an.instanceof(ApiCollectionChanges);
-    expect(apiCollectionChanges.basePath).to.equal("baseApiConfig");
-    expect(apiCollectionChanges.newPath).to.equal("newApiConfig");
+    expect(apiCollectionChanges.basePath).to.equal("baseDir");
+    expect(apiCollectionChanges.newPath).to.equal("newDir");
   });
 });
 

--- a/src/diff/changes/apiCollectionChanges.ts
+++ b/src/diff/changes/apiCollectionChanges.ts
@@ -43,8 +43,8 @@ export class ApiCollectionChanges {
 
   /**
    * Create object to hold changes to two api collections
-   * @param basePath - Base API config file
-   * @param newPath - New API config file
+   * @param basePath - Base API directory
+   * @param newPath - New API directory
    */
   constructor(public basePath: string, public newPath: string) {
     this.changed = {};

--- a/src/diff/diffCommand.test.ts
+++ b/src/diff/diffCommand.test.ts
@@ -35,10 +35,7 @@ nodeChanges.categorizedChanges = [
 ];
 const apiChanges = new ApiChanges("base/file.raml", "new/file.raml");
 apiChanges.nodeChanges = [nodeChanges];
-const apiCollectionChanges = new ApiCollectionChanges(
-  "baseApis",
-  "newApis"
-);
+const apiCollectionChanges = new ApiCollectionChanges("baseApis", "newApis");
 apiCollectionChanges.changed["file.raml"] = apiChanges;
 
 const createTempFile = (content: string): FileResult => {

--- a/src/diff/diffCommand.test.ts
+++ b/src/diff/diffCommand.test.ts
@@ -36,8 +36,8 @@ nodeChanges.categorizedChanges = [
 const apiChanges = new ApiChanges("base/file.raml", "new/file.raml");
 apiChanges.nodeChanges = [nodeChanges];
 const apiCollectionChanges = new ApiCollectionChanges(
-  "baseConfig",
-  "newConfig"
+  "baseApis",
+  "newApis"
 );
 apiCollectionChanges.changed["file.raml"] = apiChanges;
 
@@ -276,7 +276,7 @@ describe("raml-toolkit cli diff command", () => {
     .stub(diffDirectories, "diffRamlDirectories", async () => {
       throw new Error("test");
     })
-    .do(() => cmd.run(["baseConfig", "newConfig", "--dir"]))
+    .do(() => cmd.run(["baseApis", "newApis", "--dir"]))
     .exit(2)
     .it("exits non-zero when there is error while finding directory changes");
 

--- a/src/diff/diffCommand.ts
+++ b/src/diff/diffCommand.ts
@@ -23,7 +23,7 @@ This command has three modes: ruleset, diff-only, and directory.
   Directory mode compares all the files in two directories and determines if there are any differences.
 
 In ruleset and diff-only mode, the arguments must be API specification (RAML) files.
-In directory mode, the arguments must be API configuration (JSON) files.
+In directory mode, the arguments must be directories that contain APIs.
 
 Exit statuses:
   0 - No breaking changes (ruleset mode) or no differences (diff-only / directory)
@@ -69,13 +69,13 @@ Exit statuses:
       name: "base",
       required: true,
       description:
-        "The base API spec file (ruleset / diff-only mode) or configuration (directory mode)",
+        "The base API spec file (ruleset / diff-only mode) or directory",
     },
     {
       name: "new",
       required: true,
       description:
-        "The new API spec file (ruleset / diff-only mode) or configuration (directory mode)",
+        "The new API spec file (ruleset / diff-only mode) or directory",
     },
   ];
 
@@ -112,8 +112,8 @@ Exit statuses:
    * Find the differences between two directories containing API spec files.
    * Only finds differences, does not classify using a ruleset.
    *
-   * @param baseApis - Path to an API config file in the base directory
-   * @param newApis - Path to an API config file in the new directory
+   * @param baseApis - Path to base API directory
+   * @param newApis - Path to new API directory
    * @param flags - Parsed CLI flags passed to the command
    */
   protected async _diffDirs(

--- a/src/diff/diffDirectories.test.ts
+++ b/src/diff/diffDirectories.test.ts
@@ -130,8 +130,7 @@ describe("diffDirectories", () => {
 
       await diffApiMetadata(leftModel, rightModel, apiCollectionChanges);
 
-      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(1);
-      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed).to.have.all.keys("api1.raml");
       expect(apiDifferencerStub.calledOnce).to.be.true;
     });
 
@@ -168,7 +167,6 @@ describe("diffDirectories", () => {
       );
       await diffApiMetadata(leftTree, rightTree, apiCollectionChanges);
 
-      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(4);
       expect(apiCollectionChanges.changed).to.have.all.keys(
         "api1.raml",
         "api2.raml",
@@ -210,7 +208,6 @@ describe("diffDirectories", () => {
       );
       await diffApiMetadata(leftTree, rightTree, apiCollectionChanges);
 
-      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(2);
       expect(apiCollectionChanges.changed).to.have.all.keys(
         "api1.raml",
         "api2.raml"
@@ -252,7 +249,6 @@ describe("diffDirectories", () => {
       );
       await diffApiMetadata(leftTree, rightTree, apiCollectionChanges);
 
-      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(2);
       expect(apiCollectionChanges.changed).to.have.all.keys(
         "api1.raml",
         "api2.raml"
@@ -274,18 +270,17 @@ describe("diffDirectories", () => {
 
     before(() => {
       loadApiDirectoryStub = sinon.stub(loadApiDirectory, "loadApiDirectory");
+      loadApiDirectoryStub.returns(apiMetadata);
     });
 
     beforeEach(() => {
-      loadApiDirectoryStub.reset();
-      loadApiDirectoryStub.returns(apiMetadata);
+      loadApiDirectoryStub.resetHistory();
     });
 
     it("should return diff on two directories", async () => {
       const apiCollectionChanges = await diffRamlDirectories("dir1", "dir2");
 
-      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(1);
-      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed).to.have.all.keys("api1.raml");
       expect(loadApiDirectoryStub.calledTwice).to.be.true;
     });
   });

--- a/src/diff/diffDirectories.test.ts
+++ b/src/diff/diffDirectories.test.ts
@@ -4,182 +4,289 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import _ from "lodash";
 import { expect } from "chai";
-import fs from "fs-extra";
-import path from "path";
-import sinon from "sinon";
-import tmp from "tmp";
+import { default as sinon, SinonStub } from "sinon";
 
-import { diffRamlDirectories } from "./diffDirectories";
+import {
+  diffApiMetadata,
+  diffApiModels,
+  diffRamlDirectories,
+} from "./diffDirectories";
 import { ApiDifferencer } from "./apiDifferencer";
 import { ApiChanges } from "./changes/apiChanges";
+import { ApiCollectionChanges } from "./changes/apiCollectionChanges";
 import { NodeChanges } from "./changes/nodeChanges";
+import { ApiModel, ApiMetadata } from "../generate";
+import * as loadApiDirectory from "../generate/loadApiDirectory";
 
-describe("diffRamlDirectories", () => {
-  let leftDir: string;
-  let rightDir: string;
-  let leftApiConfigFile: string;
-  let rightApiConfigFile: string;
-
-  const apiConfig = {
-    family1: [
-      { assetId: "api1", fatRaml: { mainFile: "api1.raml" } },
-      { assetId: "api2", fatRaml: { mainFile: "api2.raml" } },
-    ],
-    family2: [
-      { assetId: "api3", fatRaml: { mainFile: "api3.raml" } },
-      { assetId: "api4", fatRaml: { mainFile: "api4.raml" } },
-    ],
-  };
+describe("diffDirectories", () => {
   const nodeChanges = new NodeChanges("#/web-api/endpoints/test-endpoint", [
     "apiContract:Endpoint",
   ]);
-  const apiChanges = new ApiChanges("api1/api1.raml", "api2/api2.raml");
+  const apiChanges = new ApiChanges("left.raml", "right.raml");
   apiChanges.nodeChanges = [nodeChanges];
+  let apiDifferencerStub: SinonStub;
 
-  let apiDifferencerStub;
   before(() => {
     apiDifferencerStub = sinon.stub(
       ApiDifferencer.prototype,
       "findAndCategorizeChanges"
     );
   });
-  after(() => {
-    apiDifferencerStub.restore();
-  });
 
   beforeEach(() => {
-    leftDir = tmp.dirSync().name;
-    rightDir = tmp.dirSync().name;
-    leftApiConfigFile = path.join(leftDir, "api-config.json");
-    rightApiConfigFile = path.join(rightDir, "api-config.json");
-    fs.writeJsonSync(leftApiConfigFile, apiConfig);
-    fs.copyFileSync(leftApiConfigFile, rightApiConfigFile);
     apiDifferencerStub.reset();
     apiDifferencerStub.resolves(apiChanges);
   });
 
-  it("should return diff on all the apis in api-config.json", async () => {
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
-
-    expect(Object.keys(apiCollectionChanges.changed)).to.have.length(4);
-    expect(apiDifferencerStub.callCount).to.equal(4);
-    expect(apiCollectionChanges.changed).to.have.all.keys(
-      "api1/api1.raml",
-      "api2/api2.raml",
-      "api3/api3.raml",
-      "api4/api4.raml"
-    );
-    expect(apiCollectionChanges.changed["api1/api1.raml"]).to.equal(apiChanges);
-    expect(apiCollectionChanges.changed["api2/api2.raml"]).to.equal(apiChanges);
-    expect(apiCollectionChanges.changed["api3/api3.raml"]).to.equal(apiChanges);
-    expect(apiCollectionChanges.changed["api4/api4.raml"]).to.equal(apiChanges);
+  after(() => {
+    sinon.restore();
   });
 
-  it("should not fail if ApiDifferencer throws an error", async () => {
-    const error = new Error("Not found");
-    apiDifferencerStub.rejects(error);
-    fs.writeJsonSync(leftApiConfigFile, { family1: [apiConfig["family1"][0]] });
-    fs.copyFileSync(leftApiConfigFile, rightApiConfigFile);
+  describe("diffApiModels", () => {
+    it("should report the removed api", async () => {
+      const leftModel = new ApiModel("api1", "api1.raml");
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "api1.raml",
+        "api1.raml"
+      );
 
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
+      await diffApiModels(leftModel, undefined, apiCollectionChanges);
 
-    expect(apiDifferencerStub.calledOnce).to.be.true;
-    expect(apiCollectionChanges.errored).to.have.all.keys("api1/api1.raml");
-    expect(apiCollectionChanges.errored["api1/api1.raml"]).to.equal(
-      error.message
-    );
+      expect(apiCollectionChanges.removed).to.deep.equal(["api1.raml"]);
+    });
+
+    it("should report the added api", async () => {
+      const rightModel = new ApiModel("api1", "api1.raml");
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "api1.raml",
+        "api1.raml"
+      );
+
+      await diffApiModels(undefined, rightModel, apiCollectionChanges);
+
+      expect(apiCollectionChanges.added).to.deep.equal(["api1.raml"]);
+    });
+
+    it("should not return anything for the api if no diff is found", async () => {
+      apiDifferencerStub.resolves(new ApiChanges("api1.raml", "api1.raml"));
+
+      const leftModel = new ApiModel("api1", "api1.raml");
+      const rightModel = new ApiModel("api1", "api1.raml");
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "api1.raml",
+        "api1.raml"
+      );
+
+      await diffApiModels(leftModel, rightModel, apiCollectionChanges);
+
+      expect(apiDifferencerStub.calledOnce).to.be.true;
+      expect(apiCollectionChanges.hasChanges()).to.be.false;
+      expect(apiCollectionChanges.hasErrors()).to.be.false;
+    });
+
+    it("should not fail if ApiDifferencer throws an error", async () => {
+      const error = new Error("Not found");
+      apiDifferencerStub.rejects(error);
+
+      const leftModel = new ApiModel("api1", "api1.raml");
+      const rightModel = new ApiModel("api1", "api1.raml");
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "api1.raml",
+        "api1.raml"
+      );
+
+      await diffApiModels(leftModel, rightModel, apiCollectionChanges);
+
+      expect(apiDifferencerStub.calledOnce).to.be.true;
+      expect(apiCollectionChanges.errored).to.have.all.keys("api1.raml");
+      expect(apiCollectionChanges.errored["api1.raml"]).to.equal(error.message);
+    });
+
+    it("should do nothing if both the apis are undefined", async () => {
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "api1.raml",
+        "api1.raml"
+      );
+
+      await diffApiModels(null, null, apiCollectionChanges);
+
+      expect(apiDifferencerStub.called).to.be.false;
+      expect(apiCollectionChanges.hasChanges()).to.be.false;
+      expect(apiCollectionChanges.hasErrors()).to.be.false;
+      expect(apiCollectionChanges.added).to.be.empty;
+      expect(apiCollectionChanges.removed).to.be.empty;
+    });
   });
 
-  it("should not return anything for the api if no diff is found", async () => {
-    apiDifferencerStub.resolves(
-      new ApiChanges("api1/api1.raml", "api1/api1.raml")
-    );
-    fs.writeJSONSync(leftApiConfigFile, { family1: [apiConfig["family1"][0]] });
-    fs.copyFileSync(leftApiConfigFile, rightApiConfigFile);
+  describe("diffApiMetadata", () => {
+    it("should return api diff if ApiModel objects are passed", async () => {
+      const leftModel = new ApiModel("api1", "api1.raml");
+      const rightModel = new ApiModel("api1", "api1.raml");
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "api1.raml",
+        "api1.raml"
+      );
 
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
+      await diffApiMetadata(leftModel, rightModel, apiCollectionChanges);
 
-    expect(apiDifferencerStub.calledOnce).to.be.true;
-    expect(apiCollectionChanges.hasChanges()).to.be.false;
-    expect(apiCollectionChanges.hasErrors()).to.be.false;
+      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(1);
+      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(apiDifferencerStub.calledOnce).to.be.true;
+    });
+
+    it("should return diff on all the apis that are part of the ApiMetadata", async () => {
+      const leftTree = new ApiMetadata("left");
+      const rightTree = new ApiMetadata("right");
+      const leftApiFamily1 = new ApiMetadata("family1");
+      const leftApiFamily2 = new ApiMetadata("family2");
+      const rightApiFamily1 = new ApiMetadata("family1");
+      const rightApiFamily2 = new ApiMetadata("family2");
+
+      leftApiFamily1.children = [
+        new ApiModel("api1", "api1.raml"),
+        new ApiModel("api2", "api2.raml"),
+      ];
+      leftApiFamily2.children = [
+        new ApiModel("api3", "api3.raml"),
+        new ApiModel("api4", "api4.raml"),
+      ];
+      rightApiFamily1.children = [
+        new ApiModel("api1", "api1.raml"),
+        new ApiModel("api2", "api2.raml"),
+      ];
+      rightApiFamily2.children = [
+        new ApiModel("api3", "api3.raml"),
+        new ApiModel("api4", "api4.raml"),
+      ];
+      leftTree.children = [leftApiFamily1, leftApiFamily2];
+      rightTree.children = [rightApiFamily1, rightApiFamily2];
+
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "leftTree",
+        "rightTree"
+      );
+      await diffApiMetadata(leftTree, rightTree, apiCollectionChanges);
+
+      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(4);
+      expect(apiCollectionChanges.changed).to.have.all.keys(
+        "api1.raml",
+        "api2.raml",
+        "api3.raml",
+        "api4.raml"
+      );
+      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed["api2.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed["api3.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed["api4.raml"]).to.equal(apiChanges);
+      expect(apiDifferencerStub.callCount).to.equal(4);
+    });
+
+    it("should report all the apis in the removed api family", async () => {
+      const leftTree = new ApiMetadata("left");
+      const rightTree = new ApiMetadata("right");
+      const leftApiFamily1 = new ApiMetadata("family1");
+      const leftApiFamily2 = new ApiMetadata("family2");
+      const rightApiFamily1 = new ApiMetadata("family1");
+
+      leftApiFamily1.children = [
+        new ApiModel("api1", "api1.raml"),
+        new ApiModel("api2", "api2.raml"),
+      ];
+      leftApiFamily2.children = [
+        new ApiModel("api3", "api3.raml"),
+        new ApiModel("api4", "api4.raml"),
+      ];
+      rightApiFamily1.children = [
+        new ApiModel("api1", "api1.raml"),
+        new ApiModel("api2", "api2.raml"),
+      ];
+      leftTree.children = [leftApiFamily1, leftApiFamily2];
+      rightTree.children = [rightApiFamily1];
+
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "leftTree",
+        "rightTree"
+      );
+      await diffApiMetadata(leftTree, rightTree, apiCollectionChanges);
+
+      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(2);
+      expect(apiCollectionChanges.changed).to.have.all.keys(
+        "api1.raml",
+        "api2.raml"
+      );
+      expect(apiCollectionChanges.removed).to.deep.equal([
+        "api3.raml",
+        "api4.raml",
+      ]);
+      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed["api2.raml"]).to.equal(apiChanges);
+      expect(apiDifferencerStub.callCount).to.equal(2);
+    });
+
+    it("should report all the apis in the added api family", async () => {
+      const leftTree = new ApiMetadata("left");
+      const rightTree = new ApiMetadata("right");
+      const leftApiFamily1 = new ApiMetadata("family1");
+      const rightApiFamily1 = new ApiMetadata("family1");
+      const rightApiFamily2 = new ApiMetadata("family2");
+
+      leftApiFamily1.children = [
+        new ApiModel("api1", "api1.raml"),
+        new ApiModel("api2", "api2.raml"),
+      ];
+      rightApiFamily1.children = [
+        new ApiModel("api1", "api1.raml"),
+        new ApiModel("api2", "api2.raml"),
+      ];
+      rightApiFamily2.children = [
+        new ApiModel("api3", "api3.raml"),
+        new ApiModel("api4", "api4.raml"),
+      ];
+      leftTree.children = [leftApiFamily1];
+      rightTree.children = [rightApiFamily1, rightApiFamily2];
+
+      const apiCollectionChanges = new ApiCollectionChanges(
+        "leftTree",
+        "rightTree"
+      );
+      await diffApiMetadata(leftTree, rightTree, apiCollectionChanges);
+
+      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(2);
+      expect(apiCollectionChanges.changed).to.have.all.keys(
+        "api1.raml",
+        "api2.raml"
+      );
+      expect(apiCollectionChanges.added).to.deep.equal([
+        "api3.raml",
+        "api4.raml",
+      ]);
+      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(apiCollectionChanges.changed["api2.raml"]).to.equal(apiChanges);
+      expect(apiDifferencerStub.callCount).to.equal(2);
+    });
   });
 
-  it("should report the removed apis", async () => {
-    const apiConfigCopy = _.cloneDeep(apiConfig);
-    apiConfigCopy.family2 = [apiConfig["family2"][0]];
-    fs.writeFileSync(rightApiConfigFile, JSON.stringify(apiConfigCopy));
+  describe("diffRamlDirectories", () => {
+    let loadApiDirectoryStub: SinonStub;
+    const apiMetadata = new ApiMetadata("api");
+    apiMetadata.children = [new ApiModel("api1", "api1.raml")];
 
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
+    before(() => {
+      loadApiDirectoryStub = sinon.stub(loadApiDirectory, "loadApiDirectory");
+    });
 
-    expect(apiDifferencerStub.calledThrice).to.be.true;
-    expect(apiCollectionChanges.removed).to.have.members(["api4/api4.raml"]);
-  });
+    beforeEach(() => {
+      loadApiDirectoryStub.reset();
+      loadApiDirectoryStub.returns(apiMetadata);
+    });
 
-  it("should report all the apis in the removed apiFamily", async () => {
-    fs.writeJsonSync(rightApiConfigFile, { family1: apiConfig["family1"] });
+    it("should return diff on two directories", async () => {
+      const apiCollectionChanges = await diffRamlDirectories("dir1", "dir2");
 
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
-
-    expect(apiDifferencerStub.calledTwice).to.be.true;
-    expect(apiCollectionChanges.removed).to.have.members([
-      "api3/api3.raml",
-      "api4/api4.raml",
-    ]);
-  });
-
-  it("should report added apis", async () => {
-    const apiConfigCopy = _.cloneDeep(apiConfig);
-    apiConfigCopy.family2 = [apiConfig["family2"][0]];
-    fs.writeJsonSync(leftApiConfigFile, apiConfigCopy);
-
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
-
-    expect(apiDifferencerStub.calledThrice).to.be.true;
-    expect(apiCollectionChanges.added).to.have.members(["api4/api4.raml"]);
-  });
-
-  it("should report apis in the newly added api family", async () => {
-    fs.writeJsonSync(leftApiConfigFile, { family1: apiConfig["family1"] });
-
-    const apiCollectionChanges = await diffRamlDirectories(
-      leftApiConfigFile,
-      rightApiConfigFile
-    );
-
-    expect(apiDifferencerStub.calledTwice).to.be.true;
-    expect(apiCollectionChanges.added).to.have.members([
-      "api3/api3.raml",
-      "api4/api4.raml",
-    ]);
-  });
-
-  it("works with relative paths", async () => {
-    const apiCollectionChanges = await diffRamlDirectories(
-      path.relative(process.cwd(), leftApiConfigFile),
-      path.relative(process.cwd(), rightApiConfigFile)
-    );
-
-    expect(Object.keys(apiCollectionChanges.changed)).to.have.length(4);
-    expect(apiDifferencerStub.callCount).to.equal(4);
+      expect(Object.keys(apiCollectionChanges.changed)).to.have.length(1);
+      expect(apiCollectionChanges.changed["api1.raml"]).to.equal(apiChanges);
+      expect(loadApiDirectoryStub.calledTwice).to.be.true;
+    });
   });
 });

--- a/src/diff/diffDirectories.ts
+++ b/src/diff/diffDirectories.ts
@@ -20,8 +20,8 @@ import { loadApiDirectory, ApiMetadata, ApiModel } from "../generate";
  * @param changes - ApiCollectionChanges object to contain all the changes
  */
 export async function diffApiModels(
-  leftApi: ApiModel,
-  rightApi: ApiModel,
+  leftApi: ApiModel | undefined,
+  rightApi: ApiModel | undefined,
   changes: ApiCollectionChanges
 ): Promise<void> {
   if (leftApi && rightApi) {
@@ -55,15 +55,18 @@ export async function diffApiModels(
  * @param changes - ApiCollectionChanges object to contain all the changes
  */
 export async function diffApiMetadata(
-  leftNode: ApiMetadata,
-  rightNode: ApiMetadata,
+  leftNode: ApiMetadata | undefined,
+  rightNode: ApiMetadata | undefined,
   changes: ApiCollectionChanges
 ): Promise<void> {
   // If either of the nodes passed is an ApiModel object, then we have
   // traversed that tree branch entirely and can pass the APIs for diff to
   // be run upon
-  if (leftNode instanceof ApiModel || rightNode instanceof ApiModel) {
-    return diffApiModels(leftNode as ApiModel, rightNode as ApiModel, changes);
+  if (
+    (typeof leftNode === "undefined" || leftNode instanceof ApiModel) &&
+    (typeof rightNode === "undefined" || rightNode instanceof ApiModel)
+  ) {
+    return diffApiModels(leftNode, rightNode, changes);
   }
 
   const leftChildren = leftNode ? leftNode.children : [];


### PR DESCRIPTION
* Refactor diffDirectories to use the new api structure which replaces api-config.json with .metadata.json
* Load base and new api directories into ApiMetadata trees, and then traverse and compare both the trees
* Update diff directory tests to test the new logic