### PR TITLE
Fix SLAS resource-validation-rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,7 +1555,7 @@
     },
     "@oclif/dev-cli": {
       "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.22.2.tgz",
+      "resolved": false,
       "integrity": "sha512-c7633R37RxrQIpwqPKxjNRm6/jb1yuG8fd16hmNz9Nw+/MUhEtQtKHSCe9ScH8n5M06l6LEo4ldk9LEGtpaWwA==",
       "dev": true,
       "requires": {
@@ -3163,7 +3163,7 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "resolved": false,
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
@@ -3177,7 +3177,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "resolved": false,
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
@@ -4010,7 +4010,7 @@
     },
     "depcheck": {
       "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.9.2.tgz",
+      "resolved": false,
       "integrity": "sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==",
       "dev": true,
       "requires": {
@@ -4323,7 +4323,7 @@
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "resolved": false,
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
@@ -4455,7 +4455,7 @@
     },
     "eslint-plugin-header": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
+      "resolved": false,
       "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==",
       "dev": true
     },
@@ -6683,7 +6683,7 @@
     },
     "lint-staged": {
       "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.1.tgz",
+      "resolved": false,
       "integrity": "sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==",
       "dev": true,
       "requires": {
@@ -7823,7 +7823,7 @@
     },
     "nock": {
       "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "resolved": false,
       "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
       "dev": true,
       "requires": {

--- a/resources/lint/profiles/slas.profile.test.ts
+++ b/resources/lint/profiles/slas.profile.test.ts
@@ -17,22 +17,27 @@ function loadProfile(profile: string): Record<string, any> {
 }
 
 describe("SLAS profile", () => {
-  it("matches mercury except query parameter case", () => {
+  it("matches mercury except query parameter case and resource name validation", () => {
     const mercury = loadProfile("mercury");
     const slas = loadProfile("slas");
     const camel = "camelcase-query-parameters";
+    const resourceNameValidation = "resource-name-validation";
     const snake = "snakecase-query-parameters";
 
     const mViolations = new Set<string>(mercury.violation);
     mViolations.delete(camel);
+    mViolations.delete(resourceNameValidation);
     const sViolations = new Set<string>(slas.violation);
+    sViolations.delete(resourceNameValidation);
     sViolations.delete(snake);
     expect(sViolations).to.deep.equal(mViolations);
 
     const mValidations = mercury.validations;
     delete mValidations[camel];
+    delete mValidations[resourceNameValidation];
     const sValidations = slas.validations;
     delete sValidations[snake];
+    delete sValidations[resourceNameValidation];
     expect(sValidations).to.deep.equal(mValidations);
   });
 });

--- a/resources/lint/profiles/slas.raml
+++ b/resources/lint/profiles/slas.raml
@@ -165,7 +165,7 @@ validations:
     targetClass: apiContract.EndPoint
     propertyConstraints:
       apiContract.path:
-        pattern: ^((\/[a-z][a-z0-9-]*[a-z0-9]+)|(\/\{[^}]+}))+$
+        pattern: ^((\/[a-z\.][a-z0-9-]*[a-z0-9]+)|(\/\{[^}]+}))+$
 
   unique-display-name:
     message: displayName must be unique within an API

--- a/resources/lint/profiles/slas.resource-validation.test.ts
+++ b/resources/lint/profiles/slas.resource-validation.test.ts
@@ -14,7 +14,7 @@ import {
   renderSpecAsFile,
 } from "../../../testResources/testUtils";
 
-const PROFILE = "mercury";
+const PROFILE = "slas";
 const NAME_VALIDATION =
   "http://a.ml/vocabularies/data#resource-name-validation";
 
@@ -29,11 +29,11 @@ describe("resource checking tests", () => {
     breaksTheseRules(result, [NAME_VALIDATION, NAME_VALIDATION]);
   });
 
-  it("does not conform when resource starts with a dot", async () => {
+  it("conforms when resource starts with a dot", async () => {
     const doc = getHappySpec();
     renameKey(doc, "/resource", "/.well-known");
     const result = await validateFile(renderSpecAsFile(doc), PROFILE);
-    breaksTheseRules(result, [NAME_VALIDATION, NAME_VALIDATION]);
+    conforms(result);
   });
 
   it("does not conform when resource starts with underscore", async () => {


### PR DESCRIPTION
SLAS meant to allow endpoints that start with a dot and a recent change broke that. This reverts the change.