### PR TITLE
Added Non-Breaking rule to detect addition of  endpoint operations

### DIFF
--- a/resources/diff/rules/defaultRules.json
+++ b/resources/diff/rules/defaultRules.json
@@ -208,5 +208,37 @@
         "category": "Ignored"
       }
     }
+  },
+  {
+    "name": "Operation Added",
+    "conditions": {
+      "all": [
+        {
+          "fact": "diff",
+          "path": "$.type",
+          "operator": "contains",
+          "value": "apiContract:Operation"
+        },
+        {
+          "fact": "diff",
+          "path": "$.added",
+          "operator": "hasProperty",
+          "value": "core:name"
+        },
+        {
+          "fact": "diff",
+          "path": "$.removed",
+          "operator": "hasNoProperty",
+          "value": "core:name"
+        }
+      ]
+    },
+    "event": {
+      "type": "operation-added",
+      "params": {
+        "category": "Non-Breaking",
+        "changedProperty": "core:name"
+      }
+    }
   }
 ]

--- a/src/diff/defaultRules.test.ts
+++ b/src/diff/defaultRules.test.ts
@@ -235,3 +235,19 @@ describe("Description change", () => {
     verifyRule(changes[0], rule);
   });
 });
+
+describe("Operation addition", () => {
+  it("applies operation removed rule", async () => {
+    const nodeChanges = new NodeChanges("#/web-api/end-points/resource/get", [
+      "apiContract:Operation",
+    ]);
+    nodeChanges.added = { "core:name": "newName" };
+    nodeChanges.removed = {};
+    const changes = await applyRules(
+      [nodeChanges],
+      ApiDifferencer.DEFAULT_RULES_PATH
+    );
+    const rule = defaultRules.find((r) => r.event.type === "operation-added");
+    verifyRule(changes[0], rule);
+  });
+});


### PR DESCRIPTION
Diff sample output

```
Node: #/web-api/end-points/%2Forganizations%2F%7BorganizationId%7D%2Fzones%2F%7BzoneId%7D%2Fspeed-settings/get
  [Non-Breaking] Operation Added: getSpeedSettings

Node: #/web-api/end-points/%2Forganizations%2F%7BorganizationId%7D%2Fzones%2F%7BzoneId%7D%2Fspeed-settings/patch
  [Non-Breaking] Operation Added: updateSpeedSettings
```
