### PR TITLE
Add retry option to fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,6 +1430,21 @@
         "fastq": "^1.6.0"
       }
     },
+    "@npmcli/move-file": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
+      "integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
+      "requires": {
+        "mkdirp": "^1.0.4"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        }
+      }
+    },
     "@oclif/command": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
@@ -2095,6 +2110,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
     "@types/chai": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
@@ -2237,19 +2257,9 @@
       }
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
-    },
-    "@types/node-fetch": {
-      "version": "2.5.5",
-      "resolved": false,
-      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
     },
     "@types/parse-link-header": {
       "version": "1.0.0",
@@ -2422,11 +2432,20 @@
         "es6-promisify": "^5.0.0"
       }
     },
+    "agentkeepalive": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.3.tgz",
+      "integrity": "sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
       "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
-      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -2435,14 +2454,12 @@
         "clean-stack": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-          "dev": true
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
         },
         "indent-string": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
         }
       }
     },
@@ -3055,6 +3072,71 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "cacache": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+      "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+      "requires": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -4228,6 +4310,26 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -4240,6 +4342,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+    },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -5030,17 +5137,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
-    "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5069,6 +5165,14 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
       }
     },
     "fs.realpath": {
@@ -5755,6 +5859,14 @@
         }
       }
     },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
@@ -5814,6 +5926,11 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -6130,6 +6247,11 @@
           "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
         }
       }
+    },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
     },
     "is-npm": {
       "version": "4.0.0",
@@ -6565,6 +6687,13 @@
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
+          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA=="
+        }
       }
     },
     "jsonld-streaming-parser": {
@@ -7263,6 +7392,80 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
+    "make-fetch-happen": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.10.tgz",
+      "integrity": "sha512-jPLPKQjBmDLK5r1BdyDyNKBytmkv2AsDWm2CxHJh+fqhSmC9Pmb7RQxwOq8xQig9+AWIS49+51k4f6vDQ3VnrQ==",
+      "requires": {
+        "agentkeepalive": "^4.1.0",
+        "cacache": "^15.0.0",
+        "http-cache-semantics": "^4.0.4",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^5.0.0",
+        "ssri": "^8.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4",
+            "socks": "^2.3.3"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -7347,6 +7550,80 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-fetch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.2.tgz",
+      "integrity": "sha512-/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==",
+      "requires": {
+        "encoding": "^0.1.12",
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -8470,10 +8747,31 @@
         "asap": "~2.0.3"
       }
     },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
     "promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
       "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+    },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+        }
+      }
     },
     "propagate": {
       "version": "2.0.1",
@@ -10088,6 +10386,13 @@
         "@types/rdf-js": "*",
         "JSONStream": "^1.3.3",
         "rdf-data-factory": "^1.0.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
+          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA=="
+        }
       }
     },
     "sparqljson-to-tree": {
@@ -10108,6 +10413,13 @@
         "@types/rdf-js": "*",
         "rdf-data-factory": "^1.0.2",
         "sax-stream": "^1.2.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
+          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA=="
+        }
       }
     },
     "spawn-wrap": {
@@ -10227,6 +10539,14 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+      "requires": {
+        "minipass": "^3.1.1"
       }
     },
     "staged-git-files": {
@@ -10505,6 +10825,36 @@
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
           }
+        }
+      }
+    },
+    "tar": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -10824,6 +11174,22 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "require": [
       "ts-node/register"
     ],
-    "timeout": 5000
+    "timeout": 10000
   },
   "nyc": {
     "all": true,
@@ -136,7 +136,7 @@
     "jsondiffpatch": "^0.4.1",
     "lodash": "^4.17.20",
     "loglevel": "^1.6.8",
-    "node-fetch": "^2.6.1",
+    "make-fetch-happen": "^8.0.10",
     "snyk": "^1.355.0",
     "tmp": "^0.2.0",
     "ts-node": "^8.9.1",
@@ -153,7 +153,7 @@
     "@types/js-yaml": "^3.12.2",
     "@types/jszip": "^3.1.7",
     "@types/mocha": "^8.0.3",
-    "@types/node-fetch": "^2.5.5",
+    "@types/node": "^14.14.6",
     "@types/sinon": "^9.0.0",
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^2.17.0",

--- a/src/download/bearerToken.ts
+++ b/src/download/bearerToken.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { default as fetch, Response } from "node-fetch";
+import { default as fetch, Response } from "make-fetch-happen";
 
 const MULESOFT_LOGIN = "https://anypoint.mulesoft.com/accounts/login";
 

--- a/src/download/config.ts
+++ b/src/download/config.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export const retryOptions = {
+  retries: 3,
+};

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -11,17 +11,21 @@ import {
   getVersionByDeployment,
   getSpecificApi,
   getAsset,
+  runFetch,
   search,
+  DEFAULT_DOWNLOAD_FOLDER,
 } from "./exchangeDownloader";
 import { RestApi } from "./exchangeTypes";
 import { searchAssetApiResultObject } from "../../testResources/download/resources/restApiResponseObjects";
+import * as exchangeDirectoryParser from "../download/exchangeDirectoryParser";
 
 import tmp from "tmp";
 
 import { expect, default as chai } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import nock from "nock";
 import _ from "lodash";
+import nock from "nock";
+import sinon from "sinon";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const assetSearchResults = require("../../testResources/download/resources/assetSearch.json");
@@ -34,10 +38,6 @@ const getAssetWithVersionV2 = require("../../testResources/download/resources/ge
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const getAssetWithoutVersion = require("../../testResources/download/resources/getAsset");
-
-before(() => {
-  chai.use(chaiAsPromised);
-});
 
 const REST_API: RestApi = {
   id: "8888888/test-api/1.0.0",
@@ -56,429 +56,414 @@ const REST_API: RestApi = {
   version: "1.0.0",
 };
 
-describe("downloadRestApi", () => {
-  afterEach(nock.cleanAll);
+const shopperCustomersAsset = {
+  id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1",
+  name: "Shopper Customers",
+  description:
+    "Let customers log in and manage their profiles and product lists.",
+  updatedDate: "2020-02-06T17:55:32.375Z",
+  groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+  assetId: "shopper-customers",
+  version: "0.0.1",
+  categories: {
+    "API layer": ["Process"],
+    "CC API Visibility": ["External"],
+    "CC Version Status": ["Beta"],
+    "CC API Family": ["Customer"],
+  },
+  fatRaml: {
+    classifier: "fat-raml",
+    packaging: "zip",
+    externalLink:
+      "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/bfff7ae2c59dd68e81adee900b56f8fd0d8ab00bc42206d0af3e96fa1025e9c3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJTBQMSKYL2HXJA4A%2F20200206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200206T191341Z&X-Amz-Expires=86400&X-Amz-Signature=32c30dbb73e3031ef95da76382e52acb14ad734535e108864a506a34f8e21f3f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-customers-0.0.1-raml.zip",
+    createdDate: "2020-01-22T03:25:00.200Z",
+    md5: "3ce41ea699c8be4446909f172cfac317",
+    sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
+    mainFile: "shopper-customers.raml",
+  },
+};
 
-  it("can download a single file", async () => {
-    const tmpDir = tmp.dirSync();
+describe("exchangeDownloader", () => {
+  let parserStub: sinon.SinonStub;
 
-    nock("https://somewhere").get("/fatraml.zip").reply(200);
-
-    const api = _.cloneDeep(REST_API);
-
-    return expect(downloadRestApi(api, tmpDir.name)).to.eventually.be.fulfilled;
-  });
-
-  it("can download a single file even when no download dir is specified", async () => {
-    nock("https://somewhere").get("/fatraml.zip").reply(200);
-
-    const api = _.cloneDeep(REST_API);
-
-    return expect(downloadRestApi(api)).to.eventually.be.fulfilled;
-  });
-
-  it("should not return anything if Fat RAML information is missing", async () => {
-    const api = _.cloneDeep(REST_API);
-    api.id = null;
-
-    return expect(downloadRestApi(api)).to.eventually.be.undefined;
-  });
-});
-
-describe("downloadRestApis", () => {
-  afterEach(nock.cleanAll);
-
-  it("can download multiple files", async () => {
-    const tmpDir = tmp.dirSync();
-
-    const apis = [_.cloneDeep(REST_API), _.cloneDeep(REST_API)];
-
-    apis[1].fatRaml.externalLink = "https://somewhere/fatraml2.zip";
-
-    const scope = nock("https://somewhere");
-
-    scope.get("/fatraml.zip").reply(200);
-    scope.get("/fatraml2.zip").reply(200);
-
-    return downloadRestApis(apis, tmpDir.name).then((res) => {
-      expect(res).to.equal(tmpDir.name);
-    });
-  });
-
-  it("can download multiple files even when no destination folder is provided", async () => {
-    const apis = [_.cloneDeep(REST_API), _.cloneDeep(REST_API)];
-
-    apis[1].fatRaml.externalLink = "https://somewhere/fatraml2.zip";
-
-    const scope = nock("https://somewhere");
-
-    scope.get("/fatraml.zip").reply(200);
-    scope.get("/fatraml2.zip").reply(200);
-
-    return downloadRestApis(apis).then((res) => {
-      expect(res).to.equal("download");
-    });
-  });
-
-  it("should not do anything when an empty list is passed", async () => {
-    return downloadRestApis([]).then((res) => {
-      expect(res).to.equal("download");
-    });
-  });
-});
-
-describe("searchExchange", () => {
-  afterEach(nock.cleanAll);
-
-  it("can download multiple files", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v2");
-
-    scope
-      .get("/assets?search=searchString&types=rest-api")
-      .reply(200, assetSearchResults);
-
-    return searchExchange("AUTH_TOKEN", "searchString").then((res) => {
-      expect(res).to.deep.equal(searchAssetApiResultObject);
-    });
-  });
-});
-
-describe("getSpecificApi", () => {
-  afterEach(nock.cleanAll);
-
-  it("should return the response in RestApi type", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    scope
-      .get("/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1")
-      .reply(200, getAssetWithVersion);
-
-    return expect(
-      getSpecificApi(
-        "AUTH_TOKEN",
-        "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        "shopper-customers",
-        "0.0.1"
-      )
-    ).to.eventually.deep.equal({
-      id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1",
-      name: "Shopper Customers",
-      description:
-        "Let customers log in and manage their profiles and product lists.",
-      updatedDate: "2020-02-06T17:55:32.375Z",
-      groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-      assetId: "shopper-customers",
-      version: "0.0.1",
-      categories: {
-        "API layer": ["Process"],
-        "CC API Visibility": ["External"],
-        "CC Version Status": ["Beta"],
-        "CC API Family": ["Customer"],
-      },
-      fatRaml: {
-        classifier: "fat-raml",
-        packaging: "zip",
-        externalLink:
-          "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/bfff7ae2c59dd68e81adee900b56f8fd0d8ab00bc42206d0af3e96fa1025e9c3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJTBQMSKYL2HXJA4A%2F20200206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200206T191341Z&X-Amz-Expires=86400&X-Amz-Signature=32c30dbb73e3031ef95da76382e52acb14ad734535e108864a506a34f8e21f3f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-customers-0.0.1-raml.zip",
-        createdDate: "2020-01-22T03:25:00.200Z",
-        md5: "3ce41ea699c8be4446909f172cfac317",
-        sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
-        mainFile: "shopper-customers.raml",
-      },
-    });
-  });
-
-  it("should return null if version is not provided", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    scope
-      .get("/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1")
-      .reply(200, getAssetWithVersion);
-
-    const restApi = getSpecificApi(
-      "AUTH_TOKEN",
-      "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-      "shopper-customers",
-      null
-    );
-
-    return expect(restApi).to.eventually.be.null;
-  });
-
-  it("should return null it fails to fetch the asset", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    scope
-      .get("/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1")
-      .reply(404, "Not Found");
-
-    return expect(
-      getSpecificApi(
-        "AUTH_TOKEN",
-        "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        "shopper-customers",
-        "0.0.1"
-      )
-    ).to.eventually.be.null;
-  });
-});
-
-describe("getVersionByDeployment", () => {
-  afterEach(nock.cleanAll);
-
-  it("should return a version if a deployment exists", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
-
-    return expect(
-      getVersionByDeployment("AUTH_TOKEN", REST_API, /production/i)
-    ).to.eventually.equal("0.0.1");
-  });
-
-  it("should return the base version if the deployment does not exist", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
-
-    return expect(
-      getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
-    ).to.eventually.equal(getAssetWithoutVersion.version);
-  });
-
-  it("should return undefined if the asset does not exist", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    scope.get("/8888888/test-api").reply(404, "Not Found");
-
-    return expect(
-      getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
-    ).to.eventually.be.undefined;
-  });
-
-  it("should return undefined if the asset does not have a version", async () => {
-    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
-
-    const assetWithoutVersion = _.cloneDeep(getAssetWithoutVersion);
-    delete assetWithoutVersion.version;
-
-    scope.get("/8888888/test-api").reply(200, assetWithoutVersion);
-
-    return expect(
-      getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
-    ).to.eventually.be.undefined;
-  });
-});
-
-describe("getAsset", () => {
-  it("gets the JSON asset with the specified ID", () => {
-    nock("https://anypoint.mulesoft.com/exchange/api/v1/assets")
-      .get("/8888888/test-get-asset")
-      .reply(200, { data: "json response" });
-
-    return expect(
-      getAsset("AUTH_TOKEN", "8888888/test-get-asset")
-    ).to.eventually.deep.equal({ data: "json response" });
-  });
-
-  it("returns undefined when the response indicates an error", () => {
-    nock("https://anypoint.mulesoft.com/exchange/api/v1/assets")
-      .get("/8888888/get-asset-404")
-      .reply(404, "Not Found");
-
-    return expect(getAsset("AUTH_TOKEN", "8888888/get-asset-404")).to.eventually
-      .be.undefined;
-  });
-});
-
-describe("search", () => {
-  const scope = nock(
-    "https://anypoint.mulesoft.com/exchange/api/v1/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8"
-  );
-
-  // Search uses process.env, so we need to set expected values
-  let ANYPOINT_USERNAME: string;
-  let ANYPOINT_PASSWORD: string;
   before(() => {
-    ANYPOINT_USERNAME = process.env.ANYPOINT_USERNAME;
-    ANYPOINT_PASSWORD = process.env.ANYPOINT_PASSWORD;
-    process.env.ANYPOINT_USERNAME = "user";
-    process.env.ANYPOINT_PASSWORD = "pass";
+    chai.use(chaiAsPromised);
+    parserStub = sinon.stub(exchangeDirectoryParser, "extractFile");
   });
-  // Restore the original values so other tests can use them
-  after(() => {
-    process.env.ANYPOINT_USERNAME = ANYPOINT_USERNAME;
-    process.env.ANYPOINT_PASSWORD = ANYPOINT_PASSWORD;
+
+  after(() => sinon.restore);
+
+  afterEach(() => {
+    parserStub.reset();
     nock.cleanAll();
   });
 
-  beforeEach(() => {
-    // Intercept getBearer request
-    nock("https://anypoint.mulesoft.com")
-      .post("/accounts/login", { username: "user", password: "pass" })
-      // eslint-disable-next-line @typescript-eslint/camelcase
-      .reply(200, { access_token: "AUTH_TOKEN" });
+  describe("downloadRestApi", () => {
+    const scope = nock("https://somewhere");
 
-    // Intercept searchExchange request
-    nock("https://anypoint.mulesoft.com/exchange/api/v2", {
-      reqheaders: {
-        Authorization: "Bearer AUTH_TOKEN",
-      },
-    })
-      .get("/assets?search=searchString&types=rest-api")
-      .reply(200, [assetSearchResults[0]]);
+    it("can download a single file", async () => {
+      const api = _.cloneDeep(REST_API);
+      const tmpDir = tmp.dirSync();
+
+      parserStub.resolves(tmpDir.name);
+      scope.get("/fatraml.zip").reply(200);
+
+      return expect(downloadRestApi(api, tmpDir.name)).to.eventually.be
+        .fulfilled;
+    });
+
+    it("can download a single file even when no download dir is specified", async () => {
+      const api = _.cloneDeep(REST_API);
+
+      scope.get("/fatraml.zip").reply(200);
+      parserStub.resolves(DEFAULT_DOWNLOAD_FOLDER);
+
+      return expect(downloadRestApi(api)).to.eventually.be.fulfilled;
+    });
+
+    it("should not return anything if Fat RAML information is missing", async () => {
+      const api = _.cloneDeep(REST_API);
+      api.id = null;
+
+      return expect(downloadRestApi(api)).to.eventually.be.undefined;
+    });
+
+    it("throws an error when the download api request fails with 4xx", async () => {
+      const api = _.cloneDeep(REST_API);
+
+      scope.get("/fatraml.zip").reply(403);
+
+      return expect(downloadRestApi(api, DEFAULT_DOWNLOAD_FOLDER)).to.eventually
+        .be.rejected;
+    });
   });
 
-  it("searches Exchange and filters by deployment", () => {
-    scope
-      .get("/shop-products-categories-api-v1")
-      .reply(200, getAssetWithVersion)
-      .get("/shop-products-categories-api-v1/0.0.1")
-      .reply(200, getAssetWithVersion);
+  describe("downloadRestApis", () => {
+    const scope = nock("https://somewhere");
 
-    return expect(
-      search("searchString", /production/i)
-    ).to.eventually.deep.equal([
-      {
-        id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1",
-        name: "Shopper Customers",
-        description:
-          "Let customers log in and manage their profiles and product lists.",
-        updatedDate: "2020-02-06T17:55:32.375Z",
-        groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        assetId: "shopper-customers",
-        version: "0.0.1",
-        categories: {
-          "API layer": ["Process"],
-          "CC API Visibility": ["External"],
-          "CC Version Status": ["Beta"],
-          "CC API Family": ["Customer"],
-        },
-        fatRaml: {
-          classifier: "fat-raml",
-          packaging: "zip",
-          externalLink:
-            "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/bfff7ae2c59dd68e81adee900b56f8fd0d8ab00bc42206d0af3e96fa1025e9c3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJTBQMSKYL2HXJA4A%2F20200206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200206T191341Z&X-Amz-Expires=86400&X-Amz-Signature=32c30dbb73e3031ef95da76382e52acb14ad734535e108864a506a34f8e21f3f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-customers-0.0.1-raml.zip",
-          createdDate: "2020-01-22T03:25:00.200Z",
-          md5: "3ce41ea699c8be4446909f172cfac317",
-          sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
-          mainFile: "shopper-customers.raml",
-        },
-      },
-    ]);
+    it("can download multiple files", async () => {
+      const tmpDir = tmp.dirSync();
+      const apis = [_.cloneDeep(REST_API), _.cloneDeep(REST_API)];
+      apis[1].fatRaml.externalLink = "https://somewhere/fatraml2.zip";
+
+      parserStub.resolves(tmpDir.name);
+      scope.get("/fatraml.zip").reply(200).get("/fatraml2.zip").reply(200);
+
+      return downloadRestApis(apis, tmpDir.name).then((res) => {
+        expect(res).to.equal(tmpDir.name);
+      });
+    });
+
+    it("can download multiple files even when no destination folder is provided", async () => {
+      const apis = [_.cloneDeep(REST_API), _.cloneDeep(REST_API)];
+      apis[1].fatRaml.externalLink = "https://somewhere/fatraml2.zip";
+
+      parserStub.resolves(DEFAULT_DOWNLOAD_FOLDER);
+      scope.get("/fatraml.zip").reply(200).get("/fatraml2.zip").reply(200);
+
+      return downloadRestApis(apis).then((res) => {
+        expect(res).to.equal("download");
+      });
+    });
+
+    it("should not do anything when an empty list is passed", async () => {
+      return downloadRestApis([]).then((res) =>
+        expect(res).to.equal("download")
+      );
+    });
   });
 
-  it("works when an asset does not exist", () => {
-    scope.get("/shop-products-categories-api-v1").reply(404, "Not Found");
-    return expect(
-      search("searchString", /unused regex/)
-    ).to.eventually.deep.equal([
-      {
-        id: null,
-        name: "Shopper Products",
-        description:
-          "Enable developers to add functionality that shows product details in shopping apps.",
-        updatedDate: null,
-        groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        assetId: "shop-products-categories-api-v1",
-        version: null,
-        categories: {
-          "API layer": ["Process"],
-          "CC API Family": ["Product"],
-          "CC Version Status": ["Beta"],
-          "CC API Visibility": ["External"],
-        },
-        fatRaml: {
-          classifier: "fat-raml",
-          packaging: "zip",
-          createdDate: null,
-          md5: null,
-          sha1: null,
-          mainFile: "shop-products-categories-api-v1.raml",
-        },
-      },
-    ]);
+  describe("searchExchange", () => {
+    it("can download multiple files", async () => {
+      nock("https://anypoint.mulesoft.com/exchange/api/v2")
+        .get("/assets?search=searchString&types=rest-api")
+        .reply(200, assetSearchResults);
+
+      return searchExchange("AUTH_TOKEN", "searchString").then((res) => {
+        expect(res).to.deep.equal(searchAssetApiResultObject);
+      });
+    });
   });
 
-  it("works when there are no matches for the specified deployment", () => {
-    scope
-      .get("/shop-products-categories-api-v1")
-      .reply(200, getAssetWithoutVersion)
-      .get("/shop-products-categories-api-v1/0.0.7")
-      .reply(200, getAssetWithoutVersion);
+  describe("getSpecificApi", () => {
+    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
 
-    return expect(
-      search("searchString", /nothing should match/)
-    ).to.eventually.deep.equal([
-      {
-        id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.7",
-        name: "Shopper Customers",
-        description:
-          "Let customers log in and manage their profiles and product lists.",
-        updatedDate: "2020-02-06T17:55:32.375Z",
-        groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        assetId: "shopper-customers",
-        version: "0.0.7",
-        categories: {
-          "CC API Visibility": ["External"],
-          "CC Version Status": ["Beta"],
-          "CC API Family": ["Customer"],
-          "API layer": ["Process"],
-        },
-        fatRaml: {
-          classifier: "fat-raml",
-          packaging: "zip",
-          externalLink: "https://short.url/raml.zip",
-          createdDate: "2020-02-05T21:26:01.199Z",
-          md5: "87b3ad2b2aa17639b52f0cc83c5a8d40",
-          sha1: "f2b9b2de50b7250616e2eea8843735b57235c22b",
-          mainFile: "shopper-customers.raml",
-        },
-      },
-    ]);
+    it("should return the response in RestApi type", async () => {
+      scope
+        .get("/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1")
+        .reply(200, getAssetWithVersion);
+
+      return expect(
+        getSpecificApi(
+          "AUTH_TOKEN",
+          "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+          "shopper-customers",
+          "0.0.1"
+        )
+      ).to.eventually.deep.equal(shopperCustomersAsset);
+    });
+
+    it("should return null if version is not provided", async () => {
+      scope
+        .get("/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1")
+        .reply(200, getAssetWithVersion);
+
+      const restApi = getSpecificApi(
+        "AUTH_TOKEN",
+        "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+        "shopper-customers",
+        null
+      );
+
+      return expect(restApi).to.eventually.be.null;
+    });
+
+    it("should return null it fails to fetch the asset", async () => {
+      scope
+        .get("/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1")
+        .reply(404, "Not Found");
+
+      return expect(
+        getSpecificApi(
+          "AUTH_TOKEN",
+          "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+          "shopper-customers",
+          "0.0.1"
+        )
+      ).to.eventually.be.null;
+    });
   });
 
-  /**
-   * Returns root asset version when production tag is not found
-   * on V2 API response. The actual deployed version is available
-   * under otherVersions attributes, that has no external link to download
-   * and no environmentName attribute to match
-   */
-  it("returns the root asset version without production tag on V2 response", () => {
-    scope
-      .get("/shop-products-categories-api-v1")
-      .reply(200, getAssetWithVersionV2)
-      .get("/shop-products-categories-api-v1/0.5.0")
-      .reply(200, getAssetWithVersionV2);
+  describe("getVersionByDeployment", () => {
+    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
 
-    return expect(
-      search("searchString", /production/i)
-    ).to.eventually.deep.equal([
-      {
-        id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.5.0",
-        name: "Shopper Customers",
-        description:
-          "Let customers log in and manage their profiles and product lists.",
-        updatedDate: "2020-02-06T17:55:32.375Z",
-        groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
-        assetId: "shopper-customers",
-        version: "0.5.0",
-        categories: {
-          "CC API Visibility": ["External"],
-          "CC Version Status": ["Beta"],
-          "CC API Family": ["Customer"],
-          "API layer": ["Process"],
+    it("should return a version if a deployment exists", async () => {
+      scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
+
+      return expect(
+        getVersionByDeployment("AUTH_TOKEN", REST_API, /production/i)
+      ).to.eventually.equal("0.0.1");
+    });
+
+    it("should return the base version if the deployment does not exist", async () => {
+      scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
+
+      return expect(
+        getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
+      ).to.eventually.equal(getAssetWithoutVersion.version);
+    });
+
+    it("should return undefined if the asset does not exist", async () => {
+      scope.get("/8888888/test-api").reply(404, "Not Found");
+
+      return expect(
+        getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
+      ).to.eventually.be.undefined;
+    });
+
+    it("should return undefined if the asset does not have a version", async () => {
+      const assetWithoutVersion = _.cloneDeep(getAssetWithoutVersion);
+      delete assetWithoutVersion.version;
+
+      scope.get("/8888888/test-api").reply(200, assetWithoutVersion);
+
+      return expect(
+        getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
+      ).to.eventually.be.undefined;
+    });
+  });
+
+  describe("getAsset", () => {
+    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
+    it("gets the JSON asset with the specified ID", () => {
+      scope
+        .get("/8888888/test-get-asset")
+        .reply(200, { data: "json response" });
+
+      return expect(
+        getAsset("AUTH_TOKEN", "8888888/test-get-asset")
+      ).to.eventually.deep.equal({ data: "json response" });
+    });
+
+    it("returns undefined when the response indicates an error", () => {
+      scope.get("/8888888/get-asset-404").reply(404, "Not Found");
+
+      return expect(getAsset("AUTH_TOKEN", "8888888/get-asset-404")).to
+        .eventually.be.undefined;
+    });
+  });
+
+  describe("search", () => {
+    const scope = nock(
+      "https://anypoint.mulesoft.com/exchange/api/v1/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8"
+    );
+
+    // Search uses process.env, so we need to set expected values
+    let ANYPOINT_USERNAME: string;
+    let ANYPOINT_PASSWORD: string;
+
+    before(() => {
+      ANYPOINT_USERNAME = process.env.ANYPOINT_USERNAME;
+      ANYPOINT_PASSWORD = process.env.ANYPOINT_PASSWORD;
+      process.env.ANYPOINT_USERNAME = "user";
+      process.env.ANYPOINT_PASSWORD = "pass";
+    });
+
+    // Restore the original values so other tests can use them
+    after(() => {
+      process.env.ANYPOINT_USERNAME = ANYPOINT_USERNAME;
+      process.env.ANYPOINT_PASSWORD = ANYPOINT_PASSWORD;
+    });
+
+    beforeEach(() => {
+      // Intercept getBearer request
+      nock("https://anypoint.mulesoft.com")
+        .post("/accounts/login", { username: "user", password: "pass" })
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        .reply(200, { access_token: "AUTH_TOKEN" });
+
+      // Intercept searchExchange request
+      nock("https://anypoint.mulesoft.com/exchange/api/v2", {
+        reqheaders: {
+          Authorization: "Bearer AUTH_TOKEN",
         },
-        fatRaml: {
-          classifier: "fat-raml",
-          packaging: "zip",
-          externalLink: "https://somewhere/fatraml.zip",
-          createdDate: "2020-01-22T03:25:00.200Z",
-          md5: "3ce41ea699c8be4446909f172cfac317",
-          sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
-          mainFile: "shopper-customers.raml",
+      })
+        .get("/assets?search=searchString&types=rest-api")
+        .reply(200, [assetSearchResults[0]]);
+    });
+
+    it("searches Exchange and filters by deployment", () => {
+      scope
+        .get("/shop-products-categories-api-v1")
+        .reply(200, getAssetWithVersion)
+        .get("/shop-products-categories-api-v1/0.0.1")
+        .reply(200, getAssetWithVersion);
+
+      return expect(
+        search("searchString", /production/i)
+      ).to.eventually.deep.equal([shopperCustomersAsset]);
+    });
+
+    it("works when an asset does not exist", () => {
+      scope.get("/shop-products-categories-api-v1").reply(404, "Not Found");
+
+      return expect(
+        search("searchString", /unused regex/)
+      ).to.eventually.deep.equal([
+        {
+          id: null,
+          name: "Shopper Products",
+          description:
+            "Enable developers to add functionality that shows product details in shopping apps.",
+          updatedDate: null,
+          groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+          assetId: "shop-products-categories-api-v1",
+          version: null,
+          categories: {
+            "API layer": ["Process"],
+            "CC API Family": ["Product"],
+            "CC Version Status": ["Beta"],
+            "CC API Visibility": ["External"],
+          },
+          fatRaml: {
+            classifier: "fat-raml",
+            packaging: "zip",
+            createdDate: null,
+            md5: null,
+            sha1: null,
+            mainFile: "shop-products-categories-api-v1.raml",
+          },
         },
-      },
-    ]);
+      ]);
+    });
+
+    it("works when there are no matches for the specified deployment", () => {
+      const asset = _.cloneDeep(shopperCustomersAsset);
+      asset.id = "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.7";
+      asset.version = "0.0.7";
+      asset.fatRaml = {
+        classifier: "fat-raml",
+        packaging: "zip",
+        externalLink: "https://short.url/raml.zip",
+        createdDate: "2020-02-05T21:26:01.199Z",
+        md5: "87b3ad2b2aa17639b52f0cc83c5a8d40",
+        sha1: "f2b9b2de50b7250616e2eea8843735b57235c22b",
+        mainFile: "shopper-customers.raml",
+      };
+
+      scope
+        .get("/shop-products-categories-api-v1")
+        .reply(200, getAssetWithoutVersion)
+        .get("/shop-products-categories-api-v1/0.0.7")
+        .reply(200, getAssetWithoutVersion);
+
+      return expect(
+        search("searchString", /nothing should match/)
+      ).to.eventually.deep.equal([asset]);
+    });
+
+    /**
+     * Returns root asset version when production tag is not found
+     * on V2 API response. The actual deployed version is available
+     * under otherVersions attributes, that has no external link to download
+     * and no environmentName attribute to match
+     */
+    it("returns the root asset version without production tag on V2 response", () => {
+      const asset = _.cloneDeep(shopperCustomersAsset);
+      asset.id = "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.5.0";
+      asset.version = "0.5.0";
+      asset.fatRaml.externalLink = "https://somewhere/fatraml.zip";
+      scope
+        .get("/shop-products-categories-api-v1")
+        .reply(200, getAssetWithVersionV2)
+        .get("/shop-products-categories-api-v1/0.5.0")
+        .reply(200, getAssetWithVersionV2);
+
+      return expect(
+        search("searchString", /production/i)
+      ).to.eventually.deep.equal([asset]);
+    });
+  });
+
+  describe("runFetch", () => {
+    const url = "https://somewhere";
+
+    it("retries 3 times if a request fails with 5xx", async () => {
+      const scope = nock(url)
+        .get("/fatraml.zip")
+        .thrice()
+        .reply(503)
+        .get("/fatraml.zip")
+        .reply(200);
+
+      expect((await runFetch(`${url}/fatraml.zip`)).ok).to.be.true;
+      expect(scope.isDone()).to.be.true;
+    });
+
+    it("does not retry if a request fails with 401", async () => {
+      const scope = nock(url)
+        .get("/fatraml.zip")
+        .reply(401)
+        .get("/fatraml.zip")
+        .reply(200);
+
+      expect((await runFetch(`${url}/fatraml.zip`)).status).to.equal(401);
+      expect(scope.isDone()).to.be.false;
+    });
+
+    it("can override number of retries", async () => {
+      const retryOptions = { retry: { retries: 1 } };
+      const scope = nock(url)
+        .get("/fatraml.zip")
+        .thrice()
+        .reply(503)
+        .get("/fatraml.zip")
+        .reply(200);
+
+      expect(
+        (await runFetch(`${url}/fatraml.zip`, retryOptions)).status
+      ).to.equal(503);
+      expect(scope.isDone()).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
- Replace "node-fetch" with "make-fetch-happen" which allows passing in retry options
- downloadApi function now throws error when even after retrying it fails to download an api. Earlier it logged the error when a request was unsuccessful.