### PR TITLE
Release/20200420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # CHANGELOG
+
+## 0.5.7
+* Added `isTraitDefinition` Handlebars helper to test whether an object is an
+AMF model of a RAML trait.
+* Refactored validation profiles to import rules from libraries. The rules are
+unchanged, but they are now available for use in custom validation profiles.
+
 ## 0.5.6
 * Updated profile validation rules to use SPARQL
 * Minor bug fixes

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ ARGUMENTS
   NEW   The new API spec file (ruleset / diff-only mode) or directory
 
 OPTIONS
-  -f, --format=(json|console)                        Format of the output. Defaults to JSON if --out-file is specified,
-                                                  otherwise console text.
+  -f, --format=(json|console)                     Format of the output. Defaults to JSON if --out-file is specified,
+                                                  otherwise text.
 
   -o, --out-file=out-file                         File to store the computed difference
 
@@ -60,30 +60,26 @@ OPTIONS
 
   --diff-only                                     Only show differences without evaluating a ruleset
 
-  --dir                                           Find the differences for all files in two directories
+  --dir                                           Find the differences for files in two directory trees and applies
+                                                  default ruleset
 
   --log-level=trace|debug|info|warn|error|silent  [default: info] Set the level of detail in the output
 
 DESCRIPTION
   This command has three modes: ruleset, diff-only, and directory.
-     Ruleset mode (default) compares two files and applies a ruleset to determine if any changes are breaking.
-     Diff-only mode compares two files to determine if there are any differences, without applying a ruleset.
-     Directory mode finds all exchange.json files in two directories recursively and compares all the spec files described in them. Applies the default ruleset.
+  - Ruleset mode (default) compares two files and applies a ruleset to determine if any changes are breaking.
+  - Diff-only mode compares two files to determine if there are any differences, without applying a ruleset.
+  - Directory mode finds all exchange.json files in two directories recursively and compares all the spec files 
+  described in them. Applies the default ruleset.
 
   In ruleset and diff-only mode, the arguments must be API specification (RAML) files.
-  In directory mode, the arguments must be directories containing API specification (RAML) files.
+  In directory mode, the arguments must be directories that contain exchange.json files.
 
   Exit statuses:
      0 - No breaking changes (ruleset mode) or no differences (diff-only / directory)
      1 - Breaking changes (ruleset mode) or differences found (diff only / directory)
      2 - Evaluation could not be completed
 ```
-
-More information on
-
-- [Rules](docs/diff/rules.md)
-- [Formatting the diff output](docs/diff/formatters.md)
-- [Using the diff tool as a library](docs/diff/library-usage.md)
 
 #### `raml-toolkit download`
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ OPTIONS
 ```
 <!-- commandsstop -->
 
+### Additional Information
+
+For additional information on the `diff` command, see these resources:
+
+- [Rules](docs/diff/rules.md)
+- [Formatting the diff output](docs/diff/formatters.md)
+- [Using the diff tool as a library](docs/diff/library-usage.md)
+
 ### Jenkins
 
 In your Jenkinsfile, init npm and then it's a simple one line command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce-apps/raml-toolkit",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "BSD 3-Clause",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "",
   "keywords": [
     "oclif",

--- a/src/diff/diffCommand.ts
+++ b/src/diff/diffCommand.ts
@@ -18,9 +18,9 @@ export class DiffCommand extends Command {
   // `raml-toolkit --help` only uses the first line, `raml-toolkit diff --help` skips it
   static description = `Compute the difference between two API specifications
 This command has three modes: ruleset, diff-only, and directory.
-  Ruleset mode (default) compares two files and applies a ruleset to determine if any changes are breaking.
-  Diff-only mode compares two files to determine if there are any differences, without applying a ruleset.
-  Directory mode finds all exchange.json files in two directories recursively and compares all the spec files described in them. Applies the default ruleset.
+- Ruleset mode (default) compares two files and applies a ruleset to determine if any changes are breaking.
+- Diff-only mode compares two files to determine if there are any differences, without applying a ruleset.
+- Directory mode finds all exchange.json files in two directories recursively and compares all the spec files described in them. Applies the default ruleset.
 
 In ruleset and diff-only mode, the arguments must be API specification (RAML) files.
 In directory mode, the arguments must be directories that contain exchange.json files.


### PR DESCRIPTION
Releasing [these changes](https://github.com/SalesforceCommerceCloud/raml-toolkit/compare/v0.5.6...v0.5.7).

Also updated README with generated docs. Had to move one static section out of the generated area, and tweaked the format of the diff command text due to line wrapping.