### PR TITLE
feat: update linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,11 +25,19 @@
     "@typescript-eslint/naming-convention": [
       "error",
       {
+        "selector": ["variable"],
+        "format": ["camelCase", "UPPER_CASE"]
+      },
+      {
+        "selector": ["function"],
+        "format": ["camelCase"]
+      },
+      {
         "selector": "interface",
         "format": ["PascalCase"],
         "custom": {
           "regex": "^I[A-Z]",
-          "match": false
+          "match": true
         }
       }
     ],

--- a/src/generate/handlebarsConfig.ts
+++ b/src/generate/handlebarsConfig.ts
@@ -9,6 +9,7 @@ import * as helpers from "./handlebarsAmfHelpers";
 import Handlebars from "handlebars";
 import fs from "fs-extra";
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const HandlebarsWithAmfHelpers = Handlebars.create();
 for (const helper of Object.keys(helpers)) {
   HandlebarsWithAmfHelpers.registerHelper(helper, helpers[helper]);


### PR DESCRIPTION
This PR configures new linting rules available in newer versions of eslint.We had to upgrade eslint in https://github.com/SalesforceCommerceCloud/raml-toolkit/pull/219 due to peer dependency issues that were causing the CI to fail. The new rules will enforce the following:
- variables are expected to be `camelCase` or `UPPER_CASE`
- functions are expected to be `camelCase`
- Interfaces are expected to be PascalCase and prefixed with I