### PR TITLE
feat: add custom field for class name @W-13013140@

### DIFF
--- a/src/common/structures/name.ts
+++ b/src/common/structures/name.ts
@@ -6,7 +6,7 @@
  */
 import _ from "lodash";
 
-// x-salesforce-sdk-name: custom field to set name in RAML
+// x-salesforce-sdk-class-name: custom field to set name in RAML
 export const CUSTOM_NAME_FIELD = "salesforce-sdk-class-name";
 
 /**

--- a/src/common/structures/name.ts
+++ b/src/common/structures/name.ts
@@ -7,7 +7,7 @@
 import _ from "lodash";
 
 // x-salesforce-sdk-name: custom field to set name in RAML
-export const CUSTOM_NAME_FIELD = "salesforce-sdk-name";
+export const CUSTOM_NAME_FIELD = "salesforce-sdk-class-name";
 
 /**
  * Stores a name with common transformations cached for use in templates and file paths.

--- a/src/common/structures/name.ts
+++ b/src/common/structures/name.ts
@@ -6,6 +6,9 @@
  */
 import _ from "lodash";
 
+// x-salesforce-sdk-name: custom field to set name in RAML
+export const CUSTOM_NAME_FIELD = "salesforce-sdk-name";
+
 /**
  * Stores a name with common transformations cached for use in templates and file paths.
  */

--- a/src/common/structures/name.ts
+++ b/src/common/structures/name.ts
@@ -6,9 +6,6 @@
  */
 import _ from "lodash";
 
-// x-salesforce-sdk-class-name: custom field to set name in RAML
-export const CUSTOM_NAME_FIELD = "salesforce-sdk-class-name";
-
 /**
  * Stores a name with common transformations cached for use in templates and file paths.
  */

--- a/src/generate/apiModel.test.ts
+++ b/src/generate/apiModel.test.ts
@@ -129,11 +129,11 @@ describe("ApiModel tests", () => {
     const api = new ApiModel("CUSTOM", path.dirname(customFieldRamlFile));
     await api.init();
     expect(api.model.encodes.customDomainProperties.length).to.be.equal(2);
-    // x-salesforce-sdk-name: Custom Shop API Name
+    // x-salesforce-sdk-class-name: Custom Shop API Name
     expect(
       api.model.encodes.customDomainProperties[0].name.toString()
     ).to.be.equal(CUSTOM_NAME_FIELD);
-    // x-salesforce-sdk-name: Custom Shop API Name 2 (not used)
+    // x-salesforce-sdk-class-name: Custom Shop API Name 2 (not used)
     expect(
       api.model.encodes.customDomainProperties[1].name.toString()
     ).to.be.equal(CUSTOM_NAME_FIELD);

--- a/src/generate/apiModel.test.ts
+++ b/src/generate/apiModel.test.ts
@@ -12,8 +12,8 @@ import chaiFs from "chai-fs";
 
 import fs from "fs-extra";
 
-import { ApiModel } from "./";
-import { Name, CUSTOM_NAME_FIELD } from "../common/structures/name";
+import { ApiModel, SDK_ANNOTATION } from "./";
+import { Name } from "../common/structures/name";
 import tmp from "tmp";
 import sinon from "sinon";
 
@@ -129,14 +129,14 @@ describe("ApiModel tests", () => {
     const api = new ApiModel("CUSTOM", path.dirname(customFieldRamlFile));
     await api.init();
     expect(api.model.encodes.customDomainProperties.length).to.be.equal(2);
-    // x-salesforce-sdk-class-name: Custom Shop API Name
+    // class-name: Custom Shop API Name
     expect(
       api.model.encodes.customDomainProperties[0].name.toString()
-    ).to.be.equal(CUSTOM_NAME_FIELD);
-    // x-salesforce-sdk-class-name: Custom Shop API Name 2 (not used)
+    ).to.be.equal(SDK_ANNOTATION);
+    // class-name: Custom Shop API Name 2 (not used)
     expect(
       api.model.encodes.customDomainProperties[1].name.toString()
-    ).to.be.equal(CUSTOM_NAME_FIELD);
+    ).to.be.equal(SDK_ANNOTATION);
     expect(api.name).to.deep.equal(new Name("Custom Shop API Name"));
   });
 
@@ -148,9 +148,8 @@ describe("ApiModel tests", () => {
     await api.init();
     expect(
       api.model.encodes.customDomainProperties[0].name.toString()
-    ).to.be.equal(CUSTOM_NAME_FIELD); // custom field exists but not used
+    ).to.be.equal(SDK_ANNOTATION); // custom field exists but not used
     expect(api.name).to.deep.equal(new Name("Shop API from title"));
-    expect(true);
   });
 });
 

--- a/src/generate/apiModel.test.ts
+++ b/src/generate/apiModel.test.ts
@@ -146,6 +146,9 @@ describe("ApiModel tests", () => {
       path.dirname(customFieldInvalidRamlFile)
     );
     await api.init();
+    expect(
+      api.model.encodes.customDomainProperties[0].name.toString()
+    ).to.be.equal(CUSTOM_NAME_FIELD); // custom field exists but not used
     expect(api.name).to.deep.equal(new Name("Shop API from title"));
     expect(true);
   });

--- a/src/generate/apiModel.ts
+++ b/src/generate/apiModel.ts
@@ -72,9 +72,20 @@ export class ApiModel extends ApiMetadata {
     if (!this.model) {
       throw new Error("Cannot update the name before the model is loaded");
     }
-    this.name = new Name(
-      (this.model.encodes as model.domain.WebApi)?.name.value()
-    );
+
+    // class name is defaulted to title
+    let className = (this.model.encodes as model.domain.WebApi)?.name.value();
+
+    // If user defines custom class name under `x-salesforce-sdk-name`, use that instead
+    const customClassNameArr = this.model.encodes.customDomainProperties.filter(customProperty => {
+      customProperty.name.toString() === 'salesforce-sdk-name'
+    });
+    if(customClassNameArr.length > 0) {
+      // NOTE: there can be multiple instances of `x-salesforce-sdk-name` defined, we take the value of the first one
+      className = customClassNameArr[0].extension.toString().split("=")[1];
+    }
+
+    this.name = new Name(className);
   }
 
   /**

--- a/src/generate/apiModel.ts
+++ b/src/generate/apiModel.ts
@@ -12,7 +12,7 @@ import {
   getAllDataTypes,
 } from "../common/amfParser";
 
-import { Name } from "../common/structures/name";
+import { Name, CUSTOM_NAME_FIELD } from "../common/structures/name";
 import { RestApi } from "../download/exchangeTypes";
 import path from "path";
 import fs from "fs-extra";
@@ -78,13 +78,14 @@ export class ApiModel extends ApiMetadata {
 
     // If user defines custom class name under `x-salesforce-sdk-name`, use that instead
     const customClassNameArr = this.model.encodes.customDomainProperties.filter(
-      (customProperty) => {
-        customProperty.name.toString() === "salesforce-sdk-name";
-      }
+      (customProperty) => customProperty.name.toString() === CUSTOM_NAME_FIELD
     );
     if (customClassNameArr.length > 0) {
       // NOTE: there can be multiple instances of `x-salesforce-sdk-name` defined, we take the value of the first one
-      className = customClassNameArr[0].extension.toString().split("=")[1];
+      const customClassName = customClassNameArr[0].extension
+        .toString()
+        .split("=")[1];
+      className = customClassName ? customClassName : className;
     }
 
     this.name = new Name(className);

--- a/src/generate/apiModel.ts
+++ b/src/generate/apiModel.ts
@@ -76,12 +76,12 @@ export class ApiModel extends ApiMetadata {
     // class name is defaulted to title
     let className = (this.model.encodes as model.domain.WebApi)?.name.value();
 
-    // If user defines custom class name under `x-salesforce-sdk-name`, use that instead
+    // If user defines custom class name under `x-salesforce-sdk-class-name`, use that instead
     const customClassNameArr = this.model.encodes.customDomainProperties.filter(
       (customProperty) => customProperty.name.toString() === CUSTOM_NAME_FIELD
     );
     if (customClassNameArr.length > 0) {
-      // NOTE: there can be multiple instances of `x-salesforce-sdk-name` defined, we take the value of the first one
+      // NOTE: there can be multiple instances of `x-salesforce-sdk-class-name` defined, we take the value of the first one
       const customClassName = customClassNameArr[0].extension
         .toString()
         .split("=")[1];

--- a/src/generate/apiModel.ts
+++ b/src/generate/apiModel.ts
@@ -77,10 +77,12 @@ export class ApiModel extends ApiMetadata {
     let className = (this.model.encodes as model.domain.WebApi)?.name.value();
 
     // If user defines custom class name under `x-salesforce-sdk-name`, use that instead
-    const customClassNameArr = this.model.encodes.customDomainProperties.filter(customProperty => {
-      customProperty.name.toString() === 'salesforce-sdk-name'
-    });
-    if(customClassNameArr.length > 0) {
+    const customClassNameArr = this.model.encodes.customDomainProperties.filter(
+      (customProperty) => {
+        customProperty.name.toString() === "salesforce-sdk-name";
+      }
+    );
+    if (customClassNameArr.length > 0) {
       // NOTE: there can be multiple instances of `x-salesforce-sdk-name` defined, we take the value of the first one
       className = customClassNameArr[0].extension.toString().split("=")[1];
     }

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -11,5 +11,9 @@ export * as handlebarsAmfHelpers from "./handlebarsAmfHelpers";
 export { HandlebarsWithAmfHelpers, registerPartial } from "./handlebarsConfig";
 
 export { ApiMetadata } from "./apiMetadata";
-export { ApiModel } from "./apiModel";
+export {
+  ApiModel,
+  SDK_ANNOTATION,
+  CUSTOM_CLASS_NAME_PROPERTY,
+} from "./apiModel";
 export { loadApiDirectory } from "./loadApiDirectory";

--- a/testResources/raml/custom-field-invalid/custom-field-invalid.raml
+++ b/testResources/raml/custom-field-invalid/custom-field-invalid.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Shop API from title
-x-salesforce-sdk-name:
+x-salesforce-sdk-class-name:
     displayName: Custom Shop API Name
     name: Custom Shop API Name
 baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/27d5ffea-96a7-447b-b595-2b0e837a20c6/s/-/dw/shop/v19_5

--- a/testResources/raml/custom-field-invalid/custom-field-invalid.raml
+++ b/testResources/raml/custom-field-invalid/custom-field-invalid.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+
+title: Shop API from title
+x-salesforce-sdk-name:
+    displayName: Custom Shop API Name
+    name: Custom Shop API Name
+baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/27d5ffea-96a7-447b-b595-2b0e837a20c6/s/-/dw/shop/v19_5
+version: v1
+description: This is a base shop api for testing purposes
+protocols: https
+mediaType: application/json

--- a/testResources/raml/custom-field-invalid/custom-field-invalid.raml
+++ b/testResources/raml/custom-field-invalid/custom-field-invalid.raml
@@ -1,9 +1,7 @@
 #%RAML 1.0
 
 title: Shop API from title
-x-salesforce-sdk-class-name:
-    displayName: Custom Shop API Name
-    name: Custom Shop API Name
+(commerce-sdk): Custom Shop API Name (class name not set correctly)
 baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/27d5ffea-96a7-447b-b595-2b0e837a20c6/s/-/dw/shop/v19_5
 version: v1
 description: This is a base shop api for testing purposes

--- a/testResources/raml/custom-field-invalid/exchange.json
+++ b/testResources/raml/custom-field-invalid/exchange.json
@@ -1,0 +1,12 @@
+{
+    "main": "custom-field-invalid.raml",
+    "name": "Custom Field Invalid",
+    "classifier": "raml",
+    "tags": [],
+    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+    "backwardsCompatible": false,
+    "assetId": "custom-field-invalid",
+    "version": "0.1.2",
+    "apiVersion": "v1",
+    "originalFormatVersion": "1.0"
+}

--- a/testResources/raml/custom-field/custom-field.raml
+++ b/testResources/raml/custom-field/custom-field.raml
@@ -1,8 +1,10 @@
 #%RAML 1.0
 
 title: Shop API
-x-salesforce-sdk-class-name: Custom Shop API Name
-x-salesforce-sdk-class-name: Custom Shop API Name 2 (not used)
+(commerce-sdk): 
+    class-name: Custom Shop API Name
+(commerce-sdk): 
+    class-name: Custom Shop API Name 2 (not used)
 baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/27d5ffea-96a7-447b-b595-2b0e837a20c6/s/-/dw/shop/v19_5
 version: v1
 description: This is a base shop api for testing purposes

--- a/testResources/raml/custom-field/custom-field.raml
+++ b/testResources/raml/custom-field/custom-field.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0
+
+title: Shop API
+x-salesforce-sdk-name: Custom Shop API Name
+x-salesforce-sdk-name: Custom Shop API Name 2 (not used)
+baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/27d5ffea-96a7-447b-b595-2b0e837a20c6/s/-/dw/shop/v19_5
+version: v1
+description: This is a base shop api for testing purposes
+protocols: https
+mediaType: application/json

--- a/testResources/raml/custom-field/custom-field.raml
+++ b/testResources/raml/custom-field/custom-field.raml
@@ -1,8 +1,8 @@
 #%RAML 1.0
 
 title: Shop API
-x-salesforce-sdk-name: Custom Shop API Name
-x-salesforce-sdk-name: Custom Shop API Name 2 (not used)
+x-salesforce-sdk-class-name: Custom Shop API Name
+x-salesforce-sdk-class-name: Custom Shop API Name 2 (not used)
 baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/27d5ffea-96a7-447b-b595-2b0e837a20c6/s/-/dw/shop/v19_5
 version: v1
 description: This is a base shop api for testing purposes

--- a/testResources/raml/custom-field/exchange.json
+++ b/testResources/raml/custom-field/exchange.json
@@ -1,0 +1,12 @@
+{
+    "main": "custom-field.raml",
+    "name": "Custom Field",
+    "classifier": "raml",
+    "tags": [],
+    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+    "backwardsCompatible": false,
+    "assetId": "custom-field",
+    "version": "0.1.2",
+    "apiVersion": "v1",
+    "originalFormatVersion": "1.0"
+}


### PR DESCRIPTION
This PR exposes a custom field, `x-salesforce-sdk-class-name` within the RAML file that is used for the class name for SDK generation. Previously, the class name in the SDK was defined by using the title field. Developers and Technical writers would update the title in the RAML files as they are also used for client facing documentation, leading to unintended downstream impacts onto the SDKs. To help combat these breaking changes, `x-salesforce-sdk-class-name` can be defined explicitly in the RAML file to be used for SDK class name instead of title. If the custom field does not exist, the SDK will use the title by default.

This also allows Isomorphic SDK hot fix to be reverted once the SDK is updated to consume the new RAML toolkit and the Shopper Context RAML is updated to use the custom field: https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/120

The main logic for this change is located in `src/generate/apiModel.ts`.