### PR TITLE
Release v0.5.12 - @W-15675290@

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce-apps/raml-toolkit",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "license": "BSD 3-Clause",
       "dependencies": {
         "@oclif/command": "1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "",
   "keywords": [
     "oclif",


### PR DESCRIPTION
This PR releases `raml-toolkit@0.5.12`. 

Changes include:
https://github.com/SalesforceCommerceCloud/raml-toolkit/blob/b6c45470835ded23553e15ec50b86dc2fe06b5ca/CHANGELOG.md#L3-L8

