### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.6.0
+
+* Added support for OAS files:
+  * Generate command: `raml-toolkit generate`
+  * Diff command: `raml-toolkit diff <BASE> <NEW> -s oas`
+  * Download command: `raml-toolkit-download`
+
 ## 0.5.12
 
 * Fix bug by deprecating `deployment` argument from exchange downloader `search` command the argument is now optional and ignored.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.5.12",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@commerce-apps/raml-toolkit",
-      "version": "0.5.12",
+      "version": "0.6.0",
       "license": "BSD 3-Clause",
       "dependencies": {
         "@oclif/command": "1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/raml-toolkit",
-  "version": "0.5.12",
+  "version": "0.6.0",
   "description": "",
   "keywords": [
     "oclif",


### PR DESCRIPTION
This PR releases `v0.6.0` of RAML toolkit, which adds OAS support.

In the future, we need to consider renaming this package for clarity as the main use case is supporting the SDKs, which is now OAS based, so many of the RAML features are no longer required.