### PR TITLE
@W-18706176: Changes to download latest release version of the API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,9 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install oasdiff
         run: |
-          # Download the latest oasdiff binary for Linux
-          curl -fsSL -o oasdiff "https://github.com/oasdiff/oasdiff/releases/latest/download/oasdiff_linux_amd64"
+          # Download and extract the latest oasdiff binary for Linux
+          curl -fsSL -o oasdiff.tar.gz "https://github.com/oasdiff/oasdiff/releases/latest/download/oasdiff_linux_amd64.tar.gz"
+          tar -xzf oasdiff.tar.gz
           chmod +x oasdiff
           sudo mv oasdiff /usr/local/bin/
           # Verify installation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,19 @@ jobs:
         run: |
           # Use the official install script
           curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
-          # The install script puts the binary in a local bin directory, move it to system path
-          sudo mv bin/oasdiff /usr/local/bin/
+          # Check where oasdiff was actually installed
+          which oasdiff || echo "oasdiff not in PATH, checking local directories..."
+          ls -la ./
+          ls -la bin/ 2>/dev/null || echo "No bin/ directory"
+          ls -la ./bin/ 2>/dev/null || echo "No ./bin/ directory"
+          # Try to find where the binary actually is
+          find . -name "oasdiff" -type f 2>/dev/null || echo "Binary not found in current directory"
+          # If it's not already in PATH, try to find and move it
+          if ! which oasdiff; then
+            if [ -f "./oasdiff" ]; then
+              sudo mv ./oasdiff /usr/local/bin/
+            fi
+          fi
           # Verify installation
           oasdiff --version
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,21 +28,8 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install oasdiff
         run: |
-          # Use the official install script
+          # Use the official install script - it installs directly to /usr/local/bin/
           curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
-          # Check where oasdiff was actually installed
-          which oasdiff || echo "oasdiff not in PATH, checking local directories..."
-          ls -la ./
-          ls -la bin/ 2>/dev/null || echo "No bin/ directory"
-          ls -la ./bin/ 2>/dev/null || echo "No ./bin/ directory"
-          # Try to find where the binary actually is
-          find . -name "oasdiff" -type f 2>/dev/null || echo "Binary not found in current directory"
-          # If it's not already in PATH, try to find and move it
-          if ! which oasdiff; then
-            if [ -f "./oasdiff" ]; then
-              sudo mv ./oasdiff /usr/local/bin/
-            fi
-          fi
           # Verify installation
           oasdiff --version
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Install oasdiff
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
+          sudo mv ./bin/oasdiff /usr/local/bin/
       - run: npm ci
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: npm run compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install oasdiff
         run: |
-          # Use the official install script - it installs directly to /usr/local/bin/
           curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
-          # Verify installation
           oasdiff --version
       - run: npm ci
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,12 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install oasdiff
         run: |
-          curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
-          sudo mv ./bin/oasdiff /usr/local/bin/
+          # Download the latest oasdiff binary for Linux
+          curl -fsSL -o oasdiff "https://github.com/oasdiff/oasdiff/releases/latest/download/oasdiff_linux_amd64"
+          chmod +x oasdiff
+          sudo mv oasdiff /usr/local/bin/
+          # Verify installation
+          oasdiff --version
       - run: npm ci
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: npm run compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,10 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install oasdiff
         run: |
-          # Download and extract the latest oasdiff binary for Linux
-          curl -fsSL -o oasdiff.tar.gz "https://github.com/oasdiff/oasdiff/releases/latest/download/oasdiff_linux_amd64.tar.gz"
-          tar -xzf oasdiff.tar.gz
-          chmod +x oasdiff
-          sudo mv oasdiff /usr/local/bin/
+          # Use the official install script
+          curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh
+          # The install script puts the binary in a local bin directory, move it to system path
+          sudo mv bin/oasdiff /usr/local/bin/
           # Verify installation
           oasdiff --version
       - run: npm ci

--- a/src/download/downloadCommand.test.ts
+++ b/src/download/downloadCommand.test.ts
@@ -10,6 +10,7 @@ import tmp from "tmp";
 import chai from "chai";
 import chaiFs from "chai-fs";
 import { DownloadCommand } from "./downloadCommand";
+import _ from "lodash";
 
 chai.use(chaiFs);
 
@@ -17,7 +18,9 @@ chai.use(chaiFs);
 const assetSearchResults = require("../../testResources/download/resources/assetSearch.json");
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const asset = require("../../testResources/download/resources/getAsset");
+const assetResource = require("../../testResources/download/resources/getAsset");
+// Create a local copy to avoid mutating shared test resources that other tests depend on
+const asset = _.cloneDeep(assetResource);
 // Use a shorter URL for better readability
 asset.files.find((file) => file.classifier === "fat-raml").externalLink =
   "https://short.url/raml.zip";
@@ -66,7 +69,11 @@ function setup({
       // Intercept searchExchange request
       .nock("https://anypoint.mulesoft.com/exchange/api/v2", (scope) =>
         scope
-          .get(`/assets?search=${encodeURIComponent(search)}&types=rest-api`)
+          .get(
+            `/assets?search=${encodeURIComponent(
+              search
+            )}&types=rest-api&limit=50&offset=0`
+          )
           .reply(200, [assetSearchResults[0]])
       )
       // Intercept search requests

--- a/src/download/exchangeDirectoryParser.test.ts
+++ b/src/download/exchangeDirectoryParser.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { extractFiles } from "./exchangeDirectoryParser";
+import { extractFiles, extractFile } from "./exchangeDirectoryParser";
 
 import { expect, default as chai } from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -31,6 +31,33 @@ async function createZipFile(
 
 before(() => {
   chai.use(chaiAsPromised);
+});
+
+describe("extractFile", () => {
+  it("should reject with an error message when trying to extract an invalid zip file", async () => {
+    const directory = tmp.dirSync();
+    const invalidZipPath = path.join(directory.name, "invalid.zip");
+
+    // Create a file that looks like a zip but isn't valid
+    fs.writeFileSync(invalidZipPath, "This is not a valid zip file");
+
+    await expect(extractFile(invalidZipPath)).to.be.rejectedWith(
+      `Failed to extract ${invalidZipPath}, probably not a zip file`
+    );
+  });
+
+  it("should successfully extract a valid zip file", async () => {
+    const directory = tmp.dirSync();
+    const zipPath = path.join(directory.name, "api1.zip");
+
+    // Create a valid zip file
+    await createZipFile(directory, "api1.zip");
+
+    const extractedPath = await extractFile(zipPath);
+
+    expect(fs.existsSync(extractedPath)).to.be.true;
+    expect(fs.existsSync(path.join(extractedPath, "exchange.json"))).to.be.true;
+  });
 });
 
 describe("extractFiles", () => {

--- a/src/download/exchangeDirectoryParser.test.ts
+++ b/src/download/exchangeDirectoryParser.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -8,7 +8,7 @@ import {
   downloadRestApi,
   downloadRestApis,
   searchExchange,
-  getApiVersions,
+  getLatestCleanApiVersions,
   getSpecificApi,
   getAsset,
   runFetch,
@@ -176,7 +176,7 @@ describe("exchangeDownloader", () => {
   describe("searchExchange", () => {
     it("can download multiple files", async () => {
       nock("https://anypoint.mulesoft.com/exchange/api/v2")
-        .get("/assets?search=searchString&types=rest-api")
+        .get("/assets?search=searchString&types=rest-api&limit=50&offset=0")
         .reply(200, assetSearchResults);
 
       return searchExchange("AUTH_TOKEN", "searchString").then((res) => {
@@ -234,22 +234,22 @@ describe("exchangeDownloader", () => {
     });
   });
 
-  describe("getApiVersions", () => {
+  describe("getLatestCleanApiVersions", () => {
     const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
 
     it("should return the latest version", async () => {
       scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
 
       return expect(
-        getApiVersions("AUTH_TOKEN", REST_API)
+        getLatestCleanApiVersions("AUTH_TOKEN", REST_API)
       ).to.eventually.deep.equal(["0.1.1"]);
     });
 
     it("should return undefined if the asset does not exist", async () => {
       scope.get("/8888888/test-api").reply(404, "Not Found");
 
-      return expect(getApiVersions("AUTH_TOKEN", REST_API)).to.eventually.be
-        .undefined;
+      return expect(getLatestCleanApiVersions("AUTH_TOKEN", REST_API)).to
+        .eventually.be.undefined;
     });
 
     it("should return undefined if the asset does not have a version groups", async () => {
@@ -258,8 +258,8 @@ describe("exchangeDownloader", () => {
 
       scope.get("/8888888/test-api").reply(200, assetWithoutVersion);
 
-      return expect(getApiVersions("AUTH_TOKEN", REST_API)).to.eventually.be
-        .undefined;
+      return expect(getLatestCleanApiVersions("AUTH_TOKEN", REST_API)).to
+        .eventually.be.undefined;
     });
 
     it("should return latest versions from all the version groups", async () => {
@@ -268,7 +268,7 @@ describe("exchangeDownloader", () => {
         .reply(200, getAssetWithMultipleVersionGroups);
 
       return expect(
-        getApiVersions("AUTH_TOKEN", REST_API)
+        getLatestCleanApiVersions("AUTH_TOKEN", REST_API)
       ).to.eventually.deep.equal(["2.0.10", "1.8.19"]);
     });
 
@@ -282,7 +282,7 @@ describe("exchangeDownloader", () => {
       scope.get("/8888888/test-api").reply(200, assetWithoutVersion);
 
       return expect(
-        getApiVersions("AUTH_TOKEN", REST_API)
+        getLatestCleanApiVersions("AUTH_TOKEN", REST_API)
       ).to.eventually.deep.equal([]);
     });
   });
@@ -341,7 +341,7 @@ describe("exchangeDownloader", () => {
           Authorization: "Bearer AUTH_TOKEN",
         },
       })
-        .get("/assets?search=searchString&types=rest-api")
+        .get("/assets?search=searchString&types=rest-api&limit=50&offset=0")
         .reply(200, [assetSearchResults[0]]);
     });
 
@@ -354,7 +354,6 @@ describe("exchangeDownloader", () => {
 
       return expect(search("searchString")).to.eventually.deep.equal([
         shopperCustomersAsset,
-        shopperCustomersAsset,
       ]);
     });
 
@@ -364,7 +363,7 @@ describe("exchangeDownloader", () => {
       return expect(search("searchString")).to.eventually.deep.equal([]);
     });
 
-    it("searches Exchange and returns multiple version groupd", () => {
+    it("searches Exchange and returns multiple version groups", () => {
       scope
         .get("/shop-products-categories-api-v1")
         .reply(200, getAssetWithMultipleVersionGroups)

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -237,28 +237,28 @@ describe("exchangeDownloader", () => {
   describe("getVersionByDeployment", () => {
     const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
 
-    it("should return a version if no deployment is specified", async () => {
+    it("should return the latest version if no deployment is specified", async () => {
       scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
 
       return expect(
         getVersionByDeployment("AUTH_TOKEN", REST_API)
-      ).to.eventually.equal("0.0.7");
+      ).to.eventually.equal("0.0.42");
     });
 
-    it("should return a version if a deployment exists", async () => {
+    it("should return the latest version if a deployment exists", async () => {
       scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
 
       return expect(
         getVersionByDeployment("AUTH_TOKEN", REST_API, /production/i)
-      ).to.eventually.equal("0.0.7");
+      ).to.eventually.equal("0.0.42");
     });
 
-    it("should return the base version if the deployment does not exist", async () => {
+    it("should return the latest version if the deployment does not exist", async () => {
       scope.get("/8888888/test-api").reply(200, getAssetWithoutVersion);
 
       return expect(
         getVersionByDeployment("AUTH_TOKEN", REST_API, /NOT AVAILABLE/i)
-      ).to.eventually.equal(getAssetWithoutVersion.version);
+      ).to.eventually.equal("0.0.42");
     });
 
     it("should return undefined if the asset does not exist", async () => {
@@ -343,7 +343,7 @@ describe("exchangeDownloader", () => {
       scope
         .get("/shop-products-categories-api-v1")
         .reply(200, getAssetWithVersion)
-        .get("/shop-products-categories-api-v1/0.0.1")
+        .get("/shop-products-categories-api-v1/0.0.42")
         .reply(200, getAssetWithVersion);
 
       return expect(search("searchString")).to.eventually.deep.equal([
@@ -390,7 +390,7 @@ describe("exchangeDownloader", () => {
       asset.fatRaml = {
         classifier: "fat-raml",
         packaging: "zip",
-        externalLink: "https://short.url/raml.zip",
+        externalLink: "https://short.url/test",
         createdDate: "2020-02-05T21:26:01.199Z",
         md5: "87b3ad2b2aa17639b52f0cc83c5a8d40",
         sha1: "f2b9b2de50b7250616e2eea8843735b57235c22b",
@@ -400,7 +400,7 @@ describe("exchangeDownloader", () => {
       scope
         .get("/shop-products-categories-api-v1")
         .reply(200, getAssetWithoutVersion)
-        .get("/shop-products-categories-api-v1/0.0.7")
+        .get("/shop-products-categories-api-v1/0.0.42")
         .reply(200, getAssetWithoutVersion);
 
       return expect(search("searchString")).to.eventually.deep.equal([asset]);

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -339,6 +339,11 @@ describe("exchangeDownloader", () => {
         .reply(200, [assetSearchResults[0]]);
     });
 
+    afterEach(() => {
+      // Clean up any remaining nock interceptors for this describe block
+      nock.cleanAll();
+    });
+
     it("searches Exchange and filters by deployment", () => {
       scope
         .get("/shop-products-categories-api-v1")

--- a/src/download/exchangeDownloader.test.ts
+++ b/src/download/exchangeDownloader.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/download/exchangeDownloader.ts
+++ b/src/download/exchangeDownloader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -11,6 +11,7 @@ import fs from "fs-extra";
 import path from "path";
 
 import { getBearer } from "./bearerToken";
+import { removeVersionSpecificInformation } from "./exchangeTools";
 import {
   RawRestApi,
   RestApi,
@@ -26,6 +27,9 @@ export const DEFAULT_DOWNLOAD_FOLDER = "download";
 const ANYPOINT_BASE_URI = "https://anypoint.mulesoft.com/exchange";
 const ANYPOINT_API_URI_V1 = `${ANYPOINT_BASE_URI}/api/v1`;
 const ANYPOINT_API_URI_V2 = `${ANYPOINT_BASE_URI}/api/v2`;
+const DEPLOYMENT_DEPRECATION_WARNING =
+  "The 'deployment' argument is deprecated. The latest RAML specification that is published to Anypoint Exchange will be downloaded always.";
+
 // Only allows MAJOR.MINOR.PATCH (no suffixes). see https://semver.org/
 const releaseSemverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 /**
@@ -71,10 +75,15 @@ export async function downloadRestApi(
   }
   try {
     await fs.ensureDir(destinationFolder);
-    const zipFilePath = path.join(
-      destinationFolder,
-      `${restApi.assetId}-${restApi.version}.zip`
-    );
+    let zipFilePath = path.join(destinationFolder, `${restApi.assetId}.zip`);
+
+    if (isOas) {
+      //For OAS, download clean latest versions from multiple version groups
+      zipFilePath = path.join(
+        destinationFolder,
+        `${restApi.assetId}-${restApi.version}.zip`
+      );
+    }
 
     const fatRaml = restApi.fatRaml;
     const fatOas = restApi.fatOas;
@@ -226,6 +235,149 @@ export async function searchExchange(
 }
 
 /**
+ * @description Returns the version of an api in exchange from the instance fetched asset.version value
+ *
+ * @export
+ * @param {string} accessToken
+ * @param {RestApi} restApi
+ * @param {RegExp} [deployment]
+ * @returns {Promise<string>} Returned the version string from the instance fetched asset.version value
+ */
+export async function getVersionByDeployment(
+  accessToken: string,
+  restApi: RestApi,
+  deployment?: RegExp
+): Promise<void | string> {
+  if (deployment) {
+    ramlToolLogger.warn(DEPLOYMENT_DEPRECATION_WARNING);
+  }
+  const logPrefix = "[exchangeDownloader][getVersion]";
+
+  let asset;
+  try {
+    asset = await getAsset(
+      accessToken,
+      `${restApi.groupId}/${restApi.assetId}`
+    );
+  } catch (error) {
+    ramlToolLogger.error(`${logPrefix} Error fetching asset:`, error);
+    return;
+  }
+
+  if (!asset) {
+    ramlToolLogger.log(
+      `${logPrefix} No asset found for ${restApi.assetId}, returning`
+    );
+    return;
+  }
+
+  if (!asset.version) {
+    ramlToolLogger.error(
+      `${logPrefix} The rest API ${restApi.assetId} is missing the asset.version`
+    );
+    return;
+  }
+
+  // return the most recent version of an asset from the rest API
+  return asset.version;
+}
+
+/**
+ * @description Gets details on a very specific api version combination
+ * @export
+ * @param {string} accessToken
+ * @param {string} groupId
+ * @param {string} assetId
+ * @param {string} version
+ * @returns {Promise<RestApi>}
+ */
+export async function getSpecificApi(
+  accessToken: string,
+  groupId: string,
+  assetId: string,
+  version: string
+): Promise<RestApi | null> {
+  if (!version) return null;
+  const api = await getAsset(accessToken, `${groupId}/${assetId}/${version}`);
+  return api ? convertResponseToRestApi(api) : null;
+}
+
+/**
+ * Gets information about all the APIs from exchange that match the given search
+ * string.
+ * If it fails to get information about the deployed version of an API, it
+ * removes all the version specific information from the returned object.
+ *
+ * @param query - Exchange search query
+ * @param [deployment] - RegExp matching the desired deployment targets
+ *
+ * @param isOas - True to get Open API Specifications, false for RAML
+ * @returns Information about the APIs found.
+ */
+export async function search(
+  query: string,
+  deployment?: RegExp,
+  isOas = false
+): Promise<RestApi[]> {
+  if (deployment) {
+    ramlToolLogger.warn(DEPLOYMENT_DEPRECATION_WARNING);
+  }
+
+  const token = await getBearer(
+    process.env.ANYPOINT_USERNAME,
+    process.env.ANYPOINT_PASSWORD
+  );
+  const apis = await searchExchange(token, query);
+  if (isOas) {
+    return getLatestCleanApis(apis, token);
+  }
+  const promises = apis.map(async (api) => {
+    const version = await getVersionByDeployment(token, api, deployment);
+    return version
+      ? getSpecificApi(token, api.groupId, api.assetId, version)
+      : removeVersionSpecificInformation(api);
+  });
+  return Promise.all(promises);
+}
+
+/**
+ * Gets information about all the APIs from exchange that match the given search
+ * string.
+ * If it fails to get information about the deployed version of an API, it
+ * removes all the version specific information from the returned object.
+ *
+ * @param apis - Array of apis to get the latest versions
+ * @param {string} accessToken
+ *
+ * @returns Information about the APIs found.
+ */
+export async function getLatestCleanApis(
+  apis: RestApi[],
+  accessToken: string
+): Promise<RestApi[]> {
+  // Get all API versions in parallel
+  const apiVersionPromises = apis.map(async (api) => {
+    const versions = await getLatestCleanApiVersions(accessToken, api);
+    if (!versions || versions.length === 0) {
+      return { api, versions: [] };
+    }
+    return { api, versions };
+  });
+
+  const allApiVersions = await Promise.all(apiVersionPromises);
+  // Create promises for all API versions and process them in parallel
+  const promises = [];
+  for (const { api, versions } of allApiVersions) {
+    for (const version of versions) {
+      promises.push(
+        getSpecificApi(accessToken, api.groupId, api.assetId, version)
+      );
+    }
+  }
+  return Promise.all(promises);
+}
+
+/**
  * @description Returns the latest clean (MAJOR.MINOR.PATCH) API versions from multiple version groups (V1, V2..) of an API
  *
  * @export
@@ -237,7 +389,7 @@ export async function getLatestCleanApiVersions(
   accessToken: string,
   restApi: RestApi
 ): Promise<void | string[]> {
-  const logPrefix = "[exchangeDownloader][getVersions]";
+  const logPrefix = "[exchangeDownloader][getLatestCleanApiVersions]";
 
   let asset: void | RawRestApi;
   try {
@@ -291,61 +443,4 @@ function getLatestReleaseVersion(versionGroup: {
     if (aMinor !== bMinor) return bMinor - aMinor;
     return bPatch - aPatch;
   })[0].version;
-}
-
-/**
- * @description Gets details on a very specific api version combination
- * @export
- * @param {string} accessToken
- * @param {string} groupId
- * @param {string} assetId
- * @param {string} version
- * @returns {Promise<RestApi>}
- */
-export async function getSpecificApi(
-  accessToken: string,
-  groupId: string,
-  assetId: string,
-  version: string
-): Promise<RestApi | null> {
-  if (!version) return null;
-  const api = await getAsset(accessToken, `${groupId}/${assetId}/${version}`);
-  return api ? convertResponseToRestApi(api) : null;
-}
-
-/**
- * Gets information about all the APIs from exchange that match the given search
- * string.
- * If it fails to get information about the deployed version of an API, it
- * removes all the version specific information from the returned object.
- *
- * @param query - Exchange search query
- *
- * @returns Information about the APIs found.
- */
-export async function search(query: string): Promise<RestApi[]> {
-  const token = await getBearer(
-    process.env.ANYPOINT_USERNAME,
-    process.env.ANYPOINT_PASSWORD
-  );
-  const apis = await searchExchange(token, query);
-
-  // Get all API versions in parallel
-  const apiVersionPromises = apis.map(async (api) => {
-    const versions = await getLatestCleanApiVersions(token, api);
-    if (!versions || versions.length === 0) {
-      return { api, versions: [] };
-    }
-    return { api, versions };
-  });
-
-  const allApiVersions = await Promise.all(apiVersionPromises);
-  // Create promises for all API versions and process them in parallel
-  const promises = [];
-  for (const { api, versions } of allApiVersions) {
-    for (const version of versions) {
-      promises.push(getSpecificApi(token, api.groupId, api.assetId, version));
-    }
-  }
-  return Promise.all(promises);
 }

--- a/src/download/exchangeDownloaderMultipleVersions.test.ts
+++ b/src/download/exchangeDownloaderMultipleVersions.test.ts
@@ -166,6 +166,11 @@ describe("exchangeDownloaderMultipleVersions", () => {
         .reply(200, [assetSearchResults[0]]);
     });
 
+    afterEach(() => {
+      // Clean up any remaining nock interceptors for this describe block
+      nock.cleanAll();
+    });
+
     it("searches Exchange and filters by latest version", () => {
       scope
         .get("/shop-products-categories-api-v1")

--- a/src/download/exchangeDownloaderMultipleVersions.test.ts
+++ b/src/download/exchangeDownloaderMultipleVersions.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { getLatestCleanApiVersions, search } from "./exchangeDownloader";
+import { RestApi } from "./exchangeTypes";
+
+import { expect, default as chai } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import _ from "lodash";
+import nock from "nock";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const assetSearchResults = require("../../testResources/download/resources/assetSearch.json");
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const getAssetWithVersion = require("../../testResources/download/resources/getAssetWithVersion");
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const getAssetWithMultipleVersionGroups = require("../../testResources/download/resources/getAssetWithMultipleVersionGroups.json");
+
+const REST_API: RestApi = {
+  id: "8888888/test-api/1.0.0",
+  name: "Test API",
+  groupId: "8888888",
+  assetId: "test-api",
+  fatRaml: {
+    classifier: "rest-api",
+    sha1: "sha1",
+    md5: "md5",
+    externalLink: "https://somewhere/fatraml.zip",
+    packaging: "zip",
+    createdDate: "today",
+    mainFile: "api.raml",
+  },
+  version: "1.0.0",
+};
+
+const shopperCustomersAsset = {
+  id: "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-customers/0.0.1",
+  name: "Shopper Customers",
+  description:
+    "Let customers log in and manage their profiles and product lists.",
+  updatedDate: "2020-02-06T17:55:32.375Z",
+  groupId: "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+  assetId: "shopper-customers",
+  version: "0.0.1",
+  categories: {
+    "API layer": ["Process"],
+    "CC API Visibility": ["External"],
+    "CC Version Status": ["Beta"],
+    "CC API Family": ["Customer"],
+  },
+  fatRaml: {
+    classifier: "fat-raml",
+    packaging: "zip",
+    externalLink: "https://short.url/test",
+    createdDate: "2020-01-22T03:25:00.200Z",
+    md5: "3ce41ea699c8be4446909f172cfac317",
+    sha1: "10331d32527f78bf76e0b48ab2d05945d8d141c1",
+    mainFile: "shopper-customers.raml",
+  },
+  fatOas: null,
+};
+
+describe("exchangeDownloaderMultipleVersions", () => {
+  before(() => {
+    chai.use(chaiAsPromised);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("getLatestCleanApiVersions", () => {
+    const scope = nock("https://anypoint.mulesoft.com/exchange/api/v1/assets");
+
+    it("should return the latest version", async () => {
+      scope.get("/8888888/test-api").reply(200, getAssetWithVersion);
+
+      return expect(
+        getLatestCleanApiVersions("AUTH_TOKEN", REST_API)
+      ).to.eventually.deep.equal(["0.1.1"]);
+    });
+
+    it("should return undefined if the asset does not exist", async () => {
+      scope.get("/8888888/test-api").reply(404, "Not Found");
+
+      return expect(getLatestCleanApiVersions("AUTH_TOKEN", REST_API)).to
+        .eventually.be.undefined;
+    });
+
+    it("should return undefined if the asset does not have a version groups", async () => {
+      const asset = _.cloneDeep(getAssetWithMultipleVersionGroups);
+      delete asset.versionGroups;
+
+      scope.get("/8888888/test-api").reply(200, asset);
+
+      return expect(getLatestCleanApiVersions("AUTH_TOKEN", REST_API)).to
+        .eventually.be.undefined;
+    });
+
+    it("should return latest versions from all the version groups", async () => {
+      scope
+        .get("/8888888/test-api")
+        .reply(200, getAssetWithMultipleVersionGroups);
+
+      return expect(
+        getLatestCleanApiVersions("AUTH_TOKEN", REST_API)
+      ).to.eventually.deep.equal(["2.0.10", "1.8.19"]);
+    });
+
+    it("should return empty array if the version groups does not have a version", async () => {
+      const assetWithoutVersion = _.cloneDeep(
+        getAssetWithMultipleVersionGroups
+      );
+      delete assetWithoutVersion.versionGroups[0].versions;
+      delete assetWithoutVersion.versionGroups[1].versions;
+
+      scope.get("/8888888/test-api").reply(200, assetWithoutVersion);
+
+      return expect(
+        getLatestCleanApiVersions("AUTH_TOKEN", REST_API)
+      ).to.eventually.deep.equal([]);
+    });
+  });
+
+  describe("search", () => {
+    const scope = nock(
+      "https://anypoint.mulesoft.com/exchange/api/v1/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8"
+    );
+
+    // Search uses process.env, so we need to set expected values
+    let ANYPOINT_USERNAME: string | undefined;
+    let ANYPOINT_PASSWORD: string | undefined;
+
+    before(() => {
+      ANYPOINT_USERNAME = process.env.ANYPOINT_USERNAME;
+      ANYPOINT_PASSWORD = process.env.ANYPOINT_PASSWORD;
+      process.env.ANYPOINT_USERNAME = "user";
+      process.env.ANYPOINT_PASSWORD = "pass";
+    });
+
+    // Restore the original values so other tests can use them
+    after(() => {
+      process.env.ANYPOINT_USERNAME = ANYPOINT_USERNAME;
+      process.env.ANYPOINT_PASSWORD = ANYPOINT_PASSWORD;
+    });
+
+    beforeEach(() => {
+      // Intercept getBearer request
+      nock("https://anypoint.mulesoft.com")
+        .post("/accounts/login", { username: "user", password: "pass" })
+        .reply(200, { access_token: "AUTH_TOKEN" });
+
+      // Intercept searchExchange request
+      nock("https://anypoint.mulesoft.com/exchange/api/v2", {
+        reqheaders: {
+          Authorization: "Bearer AUTH_TOKEN",
+        },
+      })
+        .get("/assets?search=searchString&types=rest-api&limit=50&offset=0")
+        .reply(200, [assetSearchResults[0]]);
+    });
+
+    it("searches Exchange and filters by latest version", () => {
+      scope
+        .get("/shop-products-categories-api-v1")
+        .reply(200, getAssetWithMultipleVersionGroups)
+        .get("/shop-products-categories-api-v1/2.0.10")
+        .reply(200, getAssetWithVersion)
+        .get("/shop-products-categories-api-v1/1.8.19")
+        .reply(200, getAssetWithVersion);
+
+      return expect(
+        search("searchString", undefined, true)
+      ).to.eventually.deep.equal([
+        shopperCustomersAsset,
+        shopperCustomersAsset,
+      ]);
+    });
+
+    it("works when an oas asset does not exist", () => {
+      scope.get("/shop-products-categories-api-v1").reply(404, "Not Found");
+
+      return expect(
+        search("searchString", undefined, true)
+      ).to.eventually.deep.equal([]);
+    });
+
+    it("searches Exchange and returns multiple version groups", () => {
+      scope
+        .get("/shop-products-categories-api-v1")
+        .reply(200, getAssetWithMultipleVersionGroups)
+        .get("/shop-products-categories-api-v1/1.8.19")
+        .reply(200, getAssetWithVersion)
+        .get("/shop-products-categories-api-v1/2.0.10")
+        .reply(200, getAssetWithVersion);
+
+      return expect(
+        search("searchString", undefined, true)
+      ).to.eventually.deep.equal([
+        shopperCustomersAsset,
+        shopperCustomersAsset,
+      ]);
+    });
+  });
+});

--- a/src/download/exchangeTypes.ts
+++ b/src/download/exchangeTypes.ts
@@ -40,6 +40,10 @@ export type RawCategories = {
 export type RawRestApi = Omit<RestApi, "categories" | "fatRaml"> & {
   categories: RawCategories[];
   files: FileInfo[];
+  instances: {
+    environmentName: string;
+    version: string;
+  }[];
   versionGroups: {
     versions: {
       version: string;

--- a/src/download/exchangeTypes.ts
+++ b/src/download/exchangeTypes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/src/download/exchangeTypes.ts
+++ b/src/download/exchangeTypes.ts
@@ -40,9 +40,10 @@ export type RawCategories = {
 export type RawRestApi = Omit<RestApi, "categories" | "fatRaml"> & {
   categories: RawCategories[];
   files: FileInfo[];
-  instances: {
-    environmentName: string;
-    version: string;
+  versionGroups: {
+    versions: {
+      version: string;
+    }[];
   }[];
 };
 

--- a/testResources/download/resources/getAssetWithMultipleVersionGroups.json
+++ b/testResources/download/resources/getAssetWithMultipleVersionGroups.json
@@ -1,0 +1,3176 @@
+{
+    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+    "assetId": "shopper-baskets-oas",
+    "version": "2.0.10-kbode.W-17297521-b3",
+    "description": "",
+    "versionGroup": "v2",
+    "productAPIVersion": "v2",
+    "isPublic": false,
+    "name": "Shopper Baskets OAS",
+    "type": "rest-api",
+    "isSnapshot": false,
+    "status": "published",
+    "assetLink": "",
+    "createdAt": "2025-03-26T09:12:53.918Z",
+    "updatedAt": "2025-05-13T11:58:35.722Z",
+    "runtimeVersion": "",
+    "attributes": [
+        {
+            "value": "v2",
+            "tagType": "attribute",
+            "key": "api-version"
+        },
+        {
+            "value": "raml",
+            "tagType": "attribute",
+            "key": null
+        },
+        {
+            "value": "oas",
+            "tagType": "attribute",
+            "key": null
+        },
+        {
+            "value": "rest",
+            "tagType": "attribute",
+            "key": null
+        },
+        {
+            "value": "api",
+            "tagType": "attribute",
+            "key": null
+        },
+        {
+            "value": "oas",
+            "tagType": "attribute",
+            "key": "original-format"
+        },
+        {
+            "value": "3.0",
+            "tagType": "attribute",
+            "key": "original-format-version"
+        },
+        {
+            "value": "v2",
+            "tagType": "attribute",
+            "key": "product-api-version"
+        }
+    ],
+    "labels": [],
+    "categories": [
+        {
+            "value": [
+                "Isomorphic",
+                "Commerce"
+            ],
+            "displayName": "SDK Type",
+            "tagType": "category",
+            "dataType": "enum",
+            "key": "SDK Type"
+        },
+        {
+            "value": [
+                "External"
+            ],
+            "displayName": "Visibility",
+            "tagType": "category",
+            "dataType": "enum",
+            "key": "Visibility"
+        }
+    ],
+    "customFields": [],
+    "tags": [
+        {
+            "value": "v2",
+            "key": "api-version"
+        },
+        {
+            "value": "raml",
+            "key": null
+        },
+        {
+            "value": "oas",
+            "key": null
+        },
+        {
+            "value": "rest",
+            "key": null
+        },
+        {
+            "value": "api",
+            "key": null
+        },
+        {
+            "value": "oas",
+            "key": "original-format"
+        },
+        {
+            "value": "3.0",
+            "key": "original-format-version"
+        },
+        {
+            "value": "v2",
+            "key": "product-api-version"
+        }
+    ],
+    "files": [
+        {
+            "classifier": "fat-oas",
+            "packaging": "zip",
+            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/f40cd797e4a8c0ba1db1be7e973ec6635638d794d6111b9c973a8a2a6dcf8226.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=74a407335d32aa22f9d1b2def32dad3dcb6299ee9e39044222a43d16175a6cce&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-fat-oas.zip",
+            "md5": "a71a0b82b459ceed42cc1c49d328379a",
+            "sha1": "376d684f6c205a6d08d4aa6198a2c2dc5ede8fbb",
+            "createdDate": "2025-03-26T09:12:52.646Z",
+            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+            "isGenerated": false
+        },
+        {
+            "classifier": "fat-raml",
+            "packaging": "zip",
+            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/94f967d41453cc44195a9c7ae6f343f5a85193863a658710d576cbf65723167d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3b14730b13d1c3a3c13310a656f214c51b4ed59a1abcb6b9176fa982694eb1b1&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+            "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+            "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+            "createdDate": "2025-03-26T09:12:52.646Z",
+            "mainFile": null,
+            "isGenerated": true
+        },
+        {
+            "classifier": "oas",
+            "packaging": "zip",
+            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8a1cee0a20be38a9a6a6c2b458ad67878a87436d959d1c762d1800a1f5669903.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3dc2f54fa2c44ac46f421ba43926a6e5bac551578e5e6f5624da672c9223a06d&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-oas.zip",
+            "md5": "ec67c7696d3fc2ba907dece2123834fe",
+            "sha1": "d7c3a48b9f0924f494a772b1c4a72ddbdfb8f835",
+            "createdDate": "2025-03-26T09:12:52.646Z",
+            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+            "isGenerated": false
+        },
+        {
+            "classifier": "raml",
+            "packaging": "zip",
+            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/4c23b2a0f569e65ca8de6eab991ca1cd2e246c60b0f095881938ad8e0433ddb9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a275f1b126ee35233a0af531cc339ef0b9d303e831693a50f3879bef32ff292c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+            "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+            "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+            "createdDate": "2025-03-26T09:12:52.646Z",
+            "mainFile": null,
+            "isGenerated": true
+        },
+        {
+            "classifier": null,
+            "packaging": "pom",
+            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/b7ce5f10043dc6658a0b1477776d7a5f8da265383e3fe9af5ac794581d9e7889.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=d2f3c1237329d60d7ba2e860526996b9c4ee10518037b8a464ef7d58e2276dc3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3.pom",
+            "md5": "2b29fde033f578406927423961bb2066",
+            "sha1": "749d7d48c49bcd76a6ad2b993fa7efba47feea57",
+            "createdDate": "2025-03-26T09:12:52.646Z",
+            "mainFile": null,
+            "isGenerated": false
+        }
+    ],
+    "dependencies": [],
+    "generated": [],
+    "createdBy": {
+        "id": "5d8000b8-d8f2-44bb-9ff4-a73fc8e9672f",
+        "userName": "MercuryInstallUser",
+        "firstName": "Mercury Install",
+        "lastName": "User"
+    },
+    "rating": 0,
+    "numberOfRates": 0,
+    "instances": [
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "mocking-service",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10-kbode.W-17297521-b3",
+            "environmentId": null,
+            "providerId": null,
+            "endpointUri": "https://anypoint.mulesoft.com/mocking/api/v1/sources/exchange/assets/893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b3/m",
+            "name": "Mocking Service",
+            "isPublic": false,
+            "type": "mocked",
+            "fullname": "Shopper Baskets OAS - Mocking Service",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20351048",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "2fbfecd2-2e53-409e-ae34-eb0e5c7d30c1",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20351048",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Sandbox - v2:20351048",
+            "environmentName": "Mercury-Sandbox",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20351136",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "2c67b0e5-2e14-4edf-ad16-7572c33b5492",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20351136",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Performance - v2:20351136",
+            "environmentName": "Mercury-Performance",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20351169",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "0ae3f4fd-53ee-4f09-913f-2c77f490c39b",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20351169",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Performance-EUC1-002 - v2:20351169",
+            "environmentName": "Mercury-Performance-EUC1-002",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20357079",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "20301f8d-57d9-4632-93de-76ef6a148427",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20357079",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Staging - v2:20357079",
+            "environmentName": "Mercury-Staging",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20358081",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "62112bb0-f06a-4f57-9a78-3537daaf028d",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20358081",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Production-EUC1-001 - v2:20358081",
+            "environmentName": "Mercury-Production-EUC1-001",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20358082",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "2d0d360a-13c4-47f7-967d-0ccabe692626",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20358082",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Production-USE1-001 - v2:20358082",
+            "environmentName": "Mercury-Production-USE1-001",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20358083",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "0da3ffdd-83e6-453d-8932-6434987f7682",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20358083",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Production-APS2-001 - v2:20358083",
+            "environmentName": "Mercury-Production-APS2-001",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        },
+        {
+            "versionGroup": "v2",
+            "organizationId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "id": "20358084",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "productAPIVersion": "v2",
+            "version": "2.0.10",
+            "environmentId": "6a8b9144-c959-4be1-9ce0-4a01a5b3cab4",
+            "providerId": null,
+            "endpointUri": null,
+            "name": "v2:20358084",
+            "isPublic": false,
+            "type": "managed",
+            "fullname": "Shopper Baskets OAS - Mercury-Production-APN1-001 - v2:20358084",
+            "environmentName": "Mercury-Production-APN1-001",
+            "environmentOrganizationName": "Commerce Cloud",
+            "assetName": "Shopper Baskets OAS"
+        }
+    ],
+    "versions": [
+        {
+            "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10",
+            "type": "rest-api",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "version": "2.0.10",
+            "versionGroup": "v2",
+            "organization": {
+                "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+            },
+            "name": "Shopper Baskets OAS",
+            "status": "published",
+            "isPublic": false,
+            "isSnapshot": false,
+            "createdAt": "2025-05-13T11:58:36.817Z",
+            "assetLink": "",
+            "runtimeVersion": "",
+            "productAPIVersion": "v2",
+            "tags": [
+                {
+                    "value": "v2",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v2",
+                    "key": "product-api-version"
+                }
+            ],
+            "labels": [],
+            "attributes": [
+                {
+                    "value": "v2",
+                    "tagType": "attribute",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "tagType": "attribute",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v2",
+                    "tagType": "attribute",
+                    "key": "product-api-version"
+                }
+            ],
+            "files": [
+                {
+                    "classifier": "fat-oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/cd04e0c380473d835aecb8a70620fc0ea8419183c3b0641bb5ce8155c79df2f6.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=fb275580ad6ea62c9e920d5460ddcaaf0b154d40a9f89d5ab054c16e98a57a37&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-fat-oas.zip",
+                    "md5": "ada35173b56a437065c8f800d5e81ed9",
+                    "sha1": "a1940e69341abf621de11560e6d50e82e04edbff",
+                    "createdDate": "2025-05-13T11:58:35.722Z",
+                    "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "fat-raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/18c647244a109642cd34158cb9ec8cfd41669d3b5d0d834b6dce934efaa506fc.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=37c6b9a882182853998a78ff61fefc2082a0b6731d84bea3b2362e4a1a3420c8&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-raml.zip",
+                    "md5": "fe5324c06fe37a956f456cf42d1b5f6c",
+                    "sha1": "c1f06316c1636532c19bb5cf671898b05e044160",
+                    "createdDate": "2025-05-13T11:58:35.722Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": "oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/915c38ad237750bd40286ca87bd08c87153070cd2dacb40e87dde2855424ef8b.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=25d3ac7495e1bbe22e331cd1c8b833e8919e3256e3caa65a36c3f6d1436efbb5&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-oas.zip",
+                    "md5": "f7d2fdb1cfad6fe3778b41c9ed5eb574",
+                    "sha1": "60453de2098a76972d080fe0f09c7df7ec44eb72",
+                    "createdDate": "2025-05-13T11:58:35.722Z",
+                    "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/13c565a4a4820b23a523598ddd6659cb869b04010df2d8510201117c81cd99a9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=be7b47a5e5aaaf1b5f60ed19a7b4befd2ff1e49aeee73105aa68bd9743cb0ce3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-raml.zip",
+                    "md5": "fe5324c06fe37a956f456cf42d1b5f6c",
+                    "sha1": "c1f06316c1636532c19bb5cf671898b05e044160",
+                    "createdDate": "2025-05-13T11:58:35.722Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": null,
+                    "packaging": "pom",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/107c75b5a52bf1a30a69e028c1cd5810af94632987c7f88cfb441a8e58ab082b.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=006026c16fb79806768b39e5083f0a8e5550ce482723ef7bd5d0d7ff6ecb6205&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10.pom",
+                    "md5": "b15ac1d4876def164f7b89c8c4b7a8d2",
+                    "sha1": "11c9c6ef2b8305a3feb5936172b753deeb874259",
+                    "createdDate": "2025-05-13T11:58:35.722Z",
+                    "mainFile": null,
+                    "isGenerated": false
+                }
+            ],
+            "metadata": {
+                "apiVersion": "v2",
+                "originalFormat": "oas",
+                "originalFormatVersion": "3.0",
+                "productApiVersion": "v2"
+            }
+        },
+        {
+            "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b3",
+            "type": "rest-api",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "version": "2.0.10-kbode.W-17297521-b3",
+            "versionGroup": "v2",
+            "organization": {
+                "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+            },
+            "name": "Shopper Baskets OAS",
+            "status": "published",
+            "isPublic": false,
+            "isSnapshot": false,
+            "createdAt": "2025-03-26T09:12:53.918Z",
+            "assetLink": "",
+            "runtimeVersion": "",
+            "productAPIVersion": "v2",
+            "tags": [
+                {
+                    "value": "v2",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v2",
+                    "key": "product-api-version"
+                }
+            ],
+            "labels": [],
+            "attributes": [
+                {
+                    "value": "v2",
+                    "tagType": "attribute",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "tagType": "attribute",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v2",
+                    "tagType": "attribute",
+                    "key": "product-api-version"
+                }
+            ],
+            "files": [
+                {
+                    "classifier": "fat-oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/f40cd797e4a8c0ba1db1be7e973ec6635638d794d6111b9c973a8a2a6dcf8226.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=74a407335d32aa22f9d1b2def32dad3dcb6299ee9e39044222a43d16175a6cce&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-fat-oas.zip",
+                    "md5": "a71a0b82b459ceed42cc1c49d328379a",
+                    "sha1": "376d684f6c205a6d08d4aa6198a2c2dc5ede8fbb",
+                    "createdDate": "2025-03-26T09:12:52.646Z",
+                    "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "fat-raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/94f967d41453cc44195a9c7ae6f343f5a85193863a658710d576cbf65723167d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3b14730b13d1c3a3c13310a656f214c51b4ed59a1abcb6b9176fa982694eb1b1&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+                    "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+                    "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+                    "createdDate": "2025-03-26T09:12:52.646Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": "oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8a1cee0a20be38a9a6a6c2b458ad67878a87436d959d1c762d1800a1f5669903.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3dc2f54fa2c44ac46f421ba43926a6e5bac551578e5e6f5624da672c9223a06d&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-oas.zip",
+                    "md5": "ec67c7696d3fc2ba907dece2123834fe",
+                    "sha1": "d7c3a48b9f0924f494a772b1c4a72ddbdfb8f835",
+                    "createdDate": "2025-03-26T09:12:52.646Z",
+                    "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/4c23b2a0f569e65ca8de6eab991ca1cd2e246c60b0f095881938ad8e0433ddb9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a275f1b126ee35233a0af531cc339ef0b9d303e831693a50f3879bef32ff292c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+                    "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+                    "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+                    "createdDate": "2025-03-26T09:12:52.646Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": null,
+                    "packaging": "pom",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/b7ce5f10043dc6658a0b1477776d7a5f8da265383e3fe9af5ac794581d9e7889.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=d2f3c1237329d60d7ba2e860526996b9c4ee10518037b8a464ef7d58e2276dc3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3.pom",
+                    "md5": "2b29fde033f578406927423961bb2066",
+                    "sha1": "749d7d48c49bcd76a6ad2b993fa7efba47feea57",
+                    "createdDate": "2025-03-26T09:12:52.646Z",
+                    "mainFile": null,
+                    "isGenerated": false
+                }
+            ],
+            "metadata": {
+                "apiVersion": "v2",
+                "originalFormat": "oas",
+                "originalFormatVersion": "3.0",
+                "productApiVersion": "v2"
+            }
+        },
+        {
+            "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b2",
+            "type": "rest-api",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "version": "2.0.10-kbode.W-17297521-b2",
+            "versionGroup": "v2",
+            "organization": {
+                "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+            },
+            "name": "Shopper Baskets OAS",
+            "status": "published",
+            "isPublic": false,
+            "isSnapshot": false,
+            "createdAt": "2025-03-24T10:51:34.76Z",
+            "assetLink": "",
+            "runtimeVersion": "",
+            "productAPIVersion": "v2",
+            "tags": [
+                {
+                    "value": "v2",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v2",
+                    "key": "product-api-version"
+                }
+            ],
+            "labels": [],
+            "attributes": [
+                {
+                    "value": "v2",
+                    "tagType": "attribute",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "tagType": "attribute",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v2",
+                    "tagType": "attribute",
+                    "key": "product-api-version"
+                }
+            ],
+            "files": [
+                {
+                    "classifier": "fat-oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/dfdebb0e29634d6924cf3b690f194387a716327def89597114a33b9a9e998e64.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=63cd5e97ed8a7a0377f2a6a303eae9fa475a05241514eaf153f848b12ad23874&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-fat-oas.zip",
+                    "md5": "16baf95635d92057d5eb19d386a460e2",
+                    "sha1": "58aa7f6cf922b22fcd0c69c80d8f07053268f0e3",
+                    "createdDate": "2025-03-24T10:51:33.641Z",
+                    "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "fat-raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e8f1b3707a957472bc2960d9ea0879ab826d268c2e875bbab0020cb6ffcb4af2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=0f6afd84b2d17240163b42da36fc2fbdac35ee65d414740ba8d1d69884f45bcf&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-raml.zip",
+                    "md5": "86b19905f8219baa22db881b897c8ac1",
+                    "sha1": "de22d1d127fa2cbefe5740d98fdaae0bc2d3ea71",
+                    "createdDate": "2025-03-24T10:51:33.641Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": "oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e081cc5bfbab190e3ac72d2ed11cf25c4239fd25df0a5e692ef7d3f5747015a3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=4573925e5c43367d0ad11154eb618051c20d23a0fc4739ba160fd1922ef2a405&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-oas.zip",
+                    "md5": "2ffd3c27cc2e16087f869efb5793c43d",
+                    "sha1": "5d584704e8833c50eea497a6b9c4c9c14b84c7fd",
+                    "createdDate": "2025-03-24T10:51:33.641Z",
+                    "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e52b7946205522162fdd3906ceeac2dd86664811d04d6236d24738dcc240d136.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=477f71ce5600c5c978e4819d97a1abe513ed59f20517cf49bdb9a6e6afb512ac&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-raml.zip",
+                    "md5": "86b19905f8219baa22db881b897c8ac1",
+                    "sha1": "de22d1d127fa2cbefe5740d98fdaae0bc2d3ea71",
+                    "createdDate": "2025-03-24T10:51:33.641Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": null,
+                    "packaging": "pom",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8358364b5c387cb3b69ed4576a7ea0cd08a1fb0d1ef8fde1012b04612dbf17d7.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=dd74b35d5c0fafe272f316f404e3a7a842b2983dc0b5304cd433250a8f7fd147&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2.pom",
+                    "md5": "e303dd91961754431f199184d3d00fae",
+                    "sha1": "ed9509564b70427bcce93e54f11ead3040d1dfa0",
+                    "createdDate": "2025-03-24T10:51:33.641Z",
+                    "mainFile": null,
+                    "isGenerated": false
+                }
+            ],
+            "metadata": {
+                "apiVersion": "v2",
+                "originalFormat": "oas",
+                "originalFormatVersion": "3.0",
+                "productApiVersion": "v2"
+            }
+        },
+        {
+            "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19",
+            "type": "rest-api",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "version": "1.8.19",
+            "versionGroup": "v1",
+            "organization": {
+                "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+            },
+            "name": "Shopper Baskets OAS",
+            "status": "published",
+            "isPublic": false,
+            "isSnapshot": false,
+            "createdAt": "2025-05-13T11:57:17.184Z",
+            "assetLink": "",
+            "runtimeVersion": "",
+            "productAPIVersion": "v1",
+            "tags": [
+                {
+                    "value": "v1",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v1",
+                    "key": "product-api-version"
+                }
+            ],
+            "labels": [],
+            "attributes": [
+                {
+                    "value": "v1",
+                    "tagType": "attribute",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "tagType": "attribute",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v1",
+                    "tagType": "attribute",
+                    "key": "product-api-version"
+                }
+            ],
+            "files": [
+                {
+                    "classifier": "fat-oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d5bef51f10a847071fa496fdcfae8ad5c6d6e8f498c8e209a84f354740043a66.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=ef579e987bc21af5572b66208fe2a539af5c279d930833ef732a735291958ebd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-fat-oas.zip",
+                    "md5": "2da51103d9c77a0e5572ccb82ddb8e20",
+                    "sha1": "127e30af830ab8ab080be0fc87c7fb7a9c932d25",
+                    "createdDate": "2025-05-13T11:57:16.155Z",
+                    "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "fat-raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/88b43a90ad29b5dc6b60597c873d92ccf77b5c1c7104e9a47bd445e3b8be54c1.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=2a5c21c7cff82753d98897676838109aefb7087f3ad60fcf4d421ce688f51b6f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-raml.zip",
+                    "md5": "cc9f2c0d09f59fc3cd3219f85a87d77c",
+                    "sha1": "63615356d049b5cbc7895d293a31375b4c378a4e",
+                    "createdDate": "2025-05-13T11:57:16.155Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": "oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/7cdcd0f4d3935c261e25c0242e3db7c15223a4186aa3b328718a088179c9c5d9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=7c4960128274748691f0e6d43a95d6625f6974c03bf17fa015c829c5e4709cd4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-oas.zip",
+                    "md5": "feac43bd06bb9809740405f1a7403bbd",
+                    "sha1": "f8f65b58c46950edc4b9b67d0448fc75debaa23a",
+                    "createdDate": "2025-05-13T11:57:16.155Z",
+                    "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/acf63889e419774fc9fa957d4453a4c52547dc717a59197884526ed23f6c7a52.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3ca543f09ef4944cca28e50545d5aa57465d3b6bcd0d220df8e934da06f318ad&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-raml.zip",
+                    "md5": "cc9f2c0d09f59fc3cd3219f85a87d77c",
+                    "sha1": "63615356d049b5cbc7895d293a31375b4c378a4e",
+                    "createdDate": "2025-05-13T11:57:16.155Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": null,
+                    "packaging": "pom",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/3e9c87c4c3d4c79fdb92f138decdad74c836f9d0455df83ce654207f7af9af3b.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=345cbb79878214fcb419d49048919b8b6de82faf1c0bbf52286048055e21ce42&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19.pom",
+                    "md5": "e2976a1b85670fac4941b0a8f4292f79",
+                    "sha1": "77cbd98a1c18604de17e77b3be45b210d94118a2",
+                    "createdDate": "2025-05-13T11:57:16.155Z",
+                    "mainFile": null,
+                    "isGenerated": false
+                }
+            ],
+            "metadata": {
+                "apiVersion": "v1",
+                "originalFormat": "oas",
+                "originalFormatVersion": "3.0",
+                "productApiVersion": "v1"
+            }
+        },
+        {
+            "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19-kbode.W-17297521-b3",
+            "type": "rest-api",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "version": "1.8.19-kbode.W-17297521-b3",
+            "versionGroup": "v1",
+            "organization": {
+                "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+            },
+            "name": "Shopper Baskets OAS",
+            "status": "published",
+            "isPublic": false,
+            "isSnapshot": false,
+            "createdAt": "2025-03-26T09:11:40.752Z",
+            "assetLink": "",
+            "runtimeVersion": "",
+            "productAPIVersion": "v1",
+            "tags": [
+                {
+                    "value": "v1",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v1",
+                    "key": "product-api-version"
+                }
+            ],
+            "labels": [],
+            "attributes": [
+                {
+                    "value": "v1",
+                    "tagType": "attribute",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "tagType": "attribute",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v1",
+                    "tagType": "attribute",
+                    "key": "product-api-version"
+                }
+            ],
+            "files": [
+                {
+                    "classifier": "fat-oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/56e8920dd018373d3eda2ca14cfc4bddc653ddf4ed91f3219d2ec7bde2f9f369.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a91fe90a5e7b6bb8939ea6913826e1d43b3b3c3e98622395aba865b7c4b79f9b&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-fat-oas.zip",
+                    "md5": "a96d6a5244e97e3c3ec343a0e957b451",
+                    "sha1": "d310da36c7d7899fe26a913035e2c399393652f1",
+                    "createdDate": "2025-03-26T09:11:39.513Z",
+                    "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "fat-raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/5c6dab15239773d33bdd8737b3785e0848780eb4bafa911f62e892f8f748b2b7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=c941ebea0cd76940dfbcd5e5626d53c4f268187eb4dc331819b81a0700ff2855&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-raml.zip",
+                    "md5": "df9c16d7b4c1ee851f59aa8eda06e700",
+                    "sha1": "2eee899a783f1ea9d56f8424b563a59b1163db88",
+                    "createdDate": "2025-03-26T09:11:39.513Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": "oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/035523f6f7093d03d95a0d43363fd041d867ef3ada40be7f071f1ede50e8de5d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=1b2636877832cc94558c3feee69fb5cf37448c262acd55696cb3fb56966201dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-oas.zip",
+                    "md5": "1425e130544dc906af818f652e5c6499",
+                    "sha1": "22a594b37cdfe95467ce807cbff8f46542919a6a",
+                    "createdDate": "2025-03-26T09:11:39.513Z",
+                    "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/c30f5d398602bf61635d2588ef0287dbfd3ddf50005ca3a8c9268e44c7d64b2c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=334162d08ee72cbedfec2f8ef01e245811438cc3915cf37d6838dcce1a70b9e2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-raml.zip",
+                    "md5": "df9c16d7b4c1ee851f59aa8eda06e700",
+                    "sha1": "2eee899a783f1ea9d56f8424b563a59b1163db88",
+                    "createdDate": "2025-03-26T09:11:39.513Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": null,
+                    "packaging": "pom",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/db8e4266d80ab156cae10bc3d83037130828514296054314fb9ac27494e97c86.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=9f64539adfe2788d7ebc29920a44bd867d98bca18a93da9395f0bac81896a7c7&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3.pom",
+                    "md5": "7924db14708cb0cc12dcc51cd25b460c",
+                    "sha1": "4244b77b5eca1b1e08359e9360684ee60e38a996",
+                    "createdDate": "2025-03-26T09:11:39.513Z",
+                    "mainFile": null,
+                    "isGenerated": false
+                }
+            ],
+            "metadata": {
+                "apiVersion": "v1",
+                "originalFormat": "oas",
+                "originalFormatVersion": "3.0",
+                "productApiVersion": "v1"
+            }
+        },
+        {
+            "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19-kbode.W-17297521-b2",
+            "type": "rest-api",
+            "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+            "assetId": "shopper-baskets-oas",
+            "version": "1.8.19-kbode.W-17297521-b2",
+            "versionGroup": "v1",
+            "organization": {
+                "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+            },
+            "name": "Shopper Baskets OAS",
+            "status": "published",
+            "isPublic": false,
+            "isSnapshot": false,
+            "createdAt": "2025-03-24T10:50:14.021Z",
+            "assetLink": "",
+            "runtimeVersion": "",
+            "productAPIVersion": "v1",
+            "tags": [
+                {
+                    "value": "v1",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v1",
+                    "key": "product-api-version"
+                }
+            ],
+            "labels": [],
+            "attributes": [
+                {
+                    "value": "v1",
+                    "tagType": "attribute",
+                    "key": "api-version"
+                },
+                {
+                    "value": "raml",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "rest",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "api",
+                    "tagType": "attribute",
+                    "key": null
+                },
+                {
+                    "value": "oas",
+                    "tagType": "attribute",
+                    "key": "original-format"
+                },
+                {
+                    "value": "3.0",
+                    "tagType": "attribute",
+                    "key": "original-format-version"
+                },
+                {
+                    "value": "v1",
+                    "tagType": "attribute",
+                    "key": "product-api-version"
+                }
+            ],
+            "files": [
+                {
+                    "classifier": "fat-oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/ab69f8eecaa790ffad2166db4fb55fbfd018ed84b853606ba840b631542f83cb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=14870b961ea33d2fb41a54c6c301b57c6d462b92e05cfe43a5ed5de2b6ba285a&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-fat-oas.zip",
+                    "md5": "2e7d8060621c7170c8e6dec8e77b186f",
+                    "sha1": "ba1f53803881bb4cae6c990f1c0c640c29a0f87f",
+                    "createdDate": "2025-03-24T10:50:12.974Z",
+                    "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "fat-raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d01df14550047d0caf07b112ad3a00224ed6e868f7ec0cd5888e1e06b84431ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=013dfa89d2d8af8a1c608ed6e2e3e81c533dad146dead0385ae907f51ea3e658&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-raml.zip",
+                    "md5": "37af3559a8bdcdb08b3421feb8b057b2",
+                    "sha1": "ec47d4eec40658202701c45496faad34b4e22db7",
+                    "createdDate": "2025-03-24T10:50:12.974Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": "oas",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/a0cdbe36038ca4d4c2aac7ce4ad38808dd72dd07fadf16e0001e935bee4f1088.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=c64f6e230a413f1213f26d1bc32cb32158c92b58a4ab66dda8e400c695b0fa16&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-oas.zip",
+                    "md5": "0dfd5920d7ad906825878617b495cb73",
+                    "sha1": "ad7b5cf76f5b82cea2c61e65832998ec7abed85e",
+                    "createdDate": "2025-03-24T10:50:12.974Z",
+                    "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                    "isGenerated": false
+                },
+                {
+                    "classifier": "raml",
+                    "packaging": "zip",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d2a215de025c961c1179295ad5d34eb29ccb4dc80f58439d99a18b7b63618fb0.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=5d33e6f93341ce7df6f115ad5d69562f9d692d1331b3a1c1acb62e9e2135feed&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-raml.zip",
+                    "md5": "37af3559a8bdcdb08b3421feb8b057b2",
+                    "sha1": "ec47d4eec40658202701c45496faad34b4e22db7",
+                    "createdDate": "2025-03-24T10:50:12.974Z",
+                    "mainFile": null,
+                    "isGenerated": true
+                },
+                {
+                    "classifier": null,
+                    "packaging": "pom",
+                    "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e72bcab5261d8dff96947993003ab195737aadab74230453d7d0f33ea8883ba2.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=36c2be1546bccedd5d800a57ca1d550f60476961fe8d5fd3c32aaa23da71eff3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2.pom",
+                    "md5": "a3ad55c7432b6ba799b62e7b09424900",
+                    "sha1": "cb67725209e512b3aa9668cc446d135f802911e0",
+                    "createdDate": "2025-03-24T10:50:12.974Z",
+                    "mainFile": null,
+                    "isGenerated": false
+                }
+            ],
+            "metadata": {
+                "apiVersion": "v1",
+                "originalFormat": "oas",
+                "originalFormatVersion": "3.0",
+                "productApiVersion": "v1"
+            }
+        }
+    ],
+    "productAPIVersions": [
+        {
+            "productAPIVersion": "v2",
+            "versionGroup": "v2",
+            "versions": [
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "2.0.10",
+                    "versionGroup": "v2",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-05-13T11:58:36.817Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v2",
+                    "tags": [
+                        {
+                            "value": "v2",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/cd04e0c380473d835aecb8a70620fc0ea8419183c3b0641bb5ce8155c79df2f6.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=fb275580ad6ea62c9e920d5460ddcaaf0b154d40a9f89d5ab054c16e98a57a37&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-fat-oas.zip",
+                            "md5": "ada35173b56a437065c8f800d5e81ed9",
+                            "sha1": "a1940e69341abf621de11560e6d50e82e04edbff",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/18c647244a109642cd34158cb9ec8cfd41669d3b5d0d834b6dce934efaa506fc.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=37c6b9a882182853998a78ff61fefc2082a0b6731d84bea3b2362e4a1a3420c8&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-raml.zip",
+                            "md5": "fe5324c06fe37a956f456cf42d1b5f6c",
+                            "sha1": "c1f06316c1636532c19bb5cf671898b05e044160",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/915c38ad237750bd40286ca87bd08c87153070cd2dacb40e87dde2855424ef8b.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=25d3ac7495e1bbe22e331cd1c8b833e8919e3256e3caa65a36c3f6d1436efbb5&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-oas.zip",
+                            "md5": "f7d2fdb1cfad6fe3778b41c9ed5eb574",
+                            "sha1": "60453de2098a76972d080fe0f09c7df7ec44eb72",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/13c565a4a4820b23a523598ddd6659cb869b04010df2d8510201117c81cd99a9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=be7b47a5e5aaaf1b5f60ed19a7b4befd2ff1e49aeee73105aa68bd9743cb0ce3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-raml.zip",
+                            "md5": "fe5324c06fe37a956f456cf42d1b5f6c",
+                            "sha1": "c1f06316c1636532c19bb5cf671898b05e044160",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/107c75b5a52bf1a30a69e028c1cd5810af94632987c7f88cfb441a8e58ab082b.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=006026c16fb79806768b39e5083f0a8e5550ce482723ef7bd5d0d7ff6ecb6205&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10.pom",
+                            "md5": "b15ac1d4876def164f7b89c8c4b7a8d2",
+                            "sha1": "11c9c6ef2b8305a3feb5936172b753deeb874259",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v2",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v2"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b3",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "2.0.10-kbode.W-17297521-b3",
+                    "versionGroup": "v2",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-26T09:12:53.918Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v2",
+                    "tags": [
+                        {
+                            "value": "v2",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/f40cd797e4a8c0ba1db1be7e973ec6635638d794d6111b9c973a8a2a6dcf8226.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=74a407335d32aa22f9d1b2def32dad3dcb6299ee9e39044222a43d16175a6cce&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-fat-oas.zip",
+                            "md5": "a71a0b82b459ceed42cc1c49d328379a",
+                            "sha1": "376d684f6c205a6d08d4aa6198a2c2dc5ede8fbb",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/94f967d41453cc44195a9c7ae6f343f5a85193863a658710d576cbf65723167d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3b14730b13d1c3a3c13310a656f214c51b4ed59a1abcb6b9176fa982694eb1b1&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+                            "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+                            "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8a1cee0a20be38a9a6a6c2b458ad67878a87436d959d1c762d1800a1f5669903.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3dc2f54fa2c44ac46f421ba43926a6e5bac551578e5e6f5624da672c9223a06d&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-oas.zip",
+                            "md5": "ec67c7696d3fc2ba907dece2123834fe",
+                            "sha1": "d7c3a48b9f0924f494a772b1c4a72ddbdfb8f835",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/4c23b2a0f569e65ca8de6eab991ca1cd2e246c60b0f095881938ad8e0433ddb9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a275f1b126ee35233a0af531cc339ef0b9d303e831693a50f3879bef32ff292c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+                            "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+                            "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/b7ce5f10043dc6658a0b1477776d7a5f8da265383e3fe9af5ac794581d9e7889.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=d2f3c1237329d60d7ba2e860526996b9c4ee10518037b8a464ef7d58e2276dc3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3.pom",
+                            "md5": "2b29fde033f578406927423961bb2066",
+                            "sha1": "749d7d48c49bcd76a6ad2b993fa7efba47feea57",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v2",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v2"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b2",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "2.0.10-kbode.W-17297521-b2",
+                    "versionGroup": "v2",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-24T10:51:34.76Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v2",
+                    "tags": [
+                        {
+                            "value": "v2",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/dfdebb0e29634d6924cf3b690f194387a716327def89597114a33b9a9e998e64.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=63cd5e97ed8a7a0377f2a6a303eae9fa475a05241514eaf153f848b12ad23874&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-fat-oas.zip",
+                            "md5": "16baf95635d92057d5eb19d386a460e2",
+                            "sha1": "58aa7f6cf922b22fcd0c69c80d8f07053268f0e3",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e8f1b3707a957472bc2960d9ea0879ab826d268c2e875bbab0020cb6ffcb4af2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=0f6afd84b2d17240163b42da36fc2fbdac35ee65d414740ba8d1d69884f45bcf&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-raml.zip",
+                            "md5": "86b19905f8219baa22db881b897c8ac1",
+                            "sha1": "de22d1d127fa2cbefe5740d98fdaae0bc2d3ea71",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e081cc5bfbab190e3ac72d2ed11cf25c4239fd25df0a5e692ef7d3f5747015a3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=4573925e5c43367d0ad11154eb618051c20d23a0fc4739ba160fd1922ef2a405&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-oas.zip",
+                            "md5": "2ffd3c27cc2e16087f869efb5793c43d",
+                            "sha1": "5d584704e8833c50eea497a6b9c4c9c14b84c7fd",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e52b7946205522162fdd3906ceeac2dd86664811d04d6236d24738dcc240d136.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=477f71ce5600c5c978e4819d97a1abe513ed59f20517cf49bdb9a6e6afb512ac&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-raml.zip",
+                            "md5": "86b19905f8219baa22db881b897c8ac1",
+                            "sha1": "de22d1d127fa2cbefe5740d98fdaae0bc2d3ea71",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8358364b5c387cb3b69ed4576a7ea0cd08a1fb0d1ef8fde1012b04612dbf17d7.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=dd74b35d5c0fafe272f316f404e3a7a842b2983dc0b5304cd433250a8f7fd147&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2.pom",
+                            "md5": "e303dd91961754431f199184d3d00fae",
+                            "sha1": "ed9509564b70427bcce93e54f11ead3040d1dfa0",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v2",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v2"
+                    }
+                }
+            ]
+        },
+        {
+            "productAPIVersion": "v1",
+            "versionGroup": "v1",
+            "versions": [
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "1.8.19",
+                    "versionGroup": "v1",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-05-13T11:57:17.184Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v1",
+                    "tags": [
+                        {
+                            "value": "v1",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d5bef51f10a847071fa496fdcfae8ad5c6d6e8f498c8e209a84f354740043a66.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=ef579e987bc21af5572b66208fe2a539af5c279d930833ef732a735291958ebd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-fat-oas.zip",
+                            "md5": "2da51103d9c77a0e5572ccb82ddb8e20",
+                            "sha1": "127e30af830ab8ab080be0fc87c7fb7a9c932d25",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/88b43a90ad29b5dc6b60597c873d92ccf77b5c1c7104e9a47bd445e3b8be54c1.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=2a5c21c7cff82753d98897676838109aefb7087f3ad60fcf4d421ce688f51b6f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-raml.zip",
+                            "md5": "cc9f2c0d09f59fc3cd3219f85a87d77c",
+                            "sha1": "63615356d049b5cbc7895d293a31375b4c378a4e",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/7cdcd0f4d3935c261e25c0242e3db7c15223a4186aa3b328718a088179c9c5d9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=7c4960128274748691f0e6d43a95d6625f6974c03bf17fa015c829c5e4709cd4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-oas.zip",
+                            "md5": "feac43bd06bb9809740405f1a7403bbd",
+                            "sha1": "f8f65b58c46950edc4b9b67d0448fc75debaa23a",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/acf63889e419774fc9fa957d4453a4c52547dc717a59197884526ed23f6c7a52.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3ca543f09ef4944cca28e50545d5aa57465d3b6bcd0d220df8e934da06f318ad&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-raml.zip",
+                            "md5": "cc9f2c0d09f59fc3cd3219f85a87d77c",
+                            "sha1": "63615356d049b5cbc7895d293a31375b4c378a4e",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/3e9c87c4c3d4c79fdb92f138decdad74c836f9d0455df83ce654207f7af9af3b.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=345cbb79878214fcb419d49048919b8b6de82faf1c0bbf52286048055e21ce42&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19.pom",
+                            "md5": "e2976a1b85670fac4941b0a8f4292f79",
+                            "sha1": "77cbd98a1c18604de17e77b3be45b210d94118a2",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v1",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v1"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19-kbode.W-17297521-b3",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "1.8.19-kbode.W-17297521-b3",
+                    "versionGroup": "v1",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-26T09:11:40.752Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v1",
+                    "tags": [
+                        {
+                            "value": "v1",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/56e8920dd018373d3eda2ca14cfc4bddc653ddf4ed91f3219d2ec7bde2f9f369.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a91fe90a5e7b6bb8939ea6913826e1d43b3b3c3e98622395aba865b7c4b79f9b&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-fat-oas.zip",
+                            "md5": "a96d6a5244e97e3c3ec343a0e957b451",
+                            "sha1": "d310da36c7d7899fe26a913035e2c399393652f1",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/5c6dab15239773d33bdd8737b3785e0848780eb4bafa911f62e892f8f748b2b7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=c941ebea0cd76940dfbcd5e5626d53c4f268187eb4dc331819b81a0700ff2855&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-raml.zip",
+                            "md5": "df9c16d7b4c1ee851f59aa8eda06e700",
+                            "sha1": "2eee899a783f1ea9d56f8424b563a59b1163db88",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/035523f6f7093d03d95a0d43363fd041d867ef3ada40be7f071f1ede50e8de5d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=1b2636877832cc94558c3feee69fb5cf37448c262acd55696cb3fb56966201dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-oas.zip",
+                            "md5": "1425e130544dc906af818f652e5c6499",
+                            "sha1": "22a594b37cdfe95467ce807cbff8f46542919a6a",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/c30f5d398602bf61635d2588ef0287dbfd3ddf50005ca3a8c9268e44c7d64b2c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=334162d08ee72cbedfec2f8ef01e245811438cc3915cf37d6838dcce1a70b9e2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-raml.zip",
+                            "md5": "df9c16d7b4c1ee851f59aa8eda06e700",
+                            "sha1": "2eee899a783f1ea9d56f8424b563a59b1163db88",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/db8e4266d80ab156cae10bc3d83037130828514296054314fb9ac27494e97c86.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=9f64539adfe2788d7ebc29920a44bd867d98bca18a93da9395f0bac81896a7c7&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3.pom",
+                            "md5": "7924db14708cb0cc12dcc51cd25b460c",
+                            "sha1": "4244b77b5eca1b1e08359e9360684ee60e38a996",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v1",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v1"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19-kbode.W-17297521-b2",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "1.8.19-kbode.W-17297521-b2",
+                    "versionGroup": "v1",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-24T10:50:14.021Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v1",
+                    "tags": [
+                        {
+                            "value": "v1",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/ab69f8eecaa790ffad2166db4fb55fbfd018ed84b853606ba840b631542f83cb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=14870b961ea33d2fb41a54c6c301b57c6d462b92e05cfe43a5ed5de2b6ba285a&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-fat-oas.zip",
+                            "md5": "2e7d8060621c7170c8e6dec8e77b186f",
+                            "sha1": "ba1f53803881bb4cae6c990f1c0c640c29a0f87f",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d01df14550047d0caf07b112ad3a00224ed6e868f7ec0cd5888e1e06b84431ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=013dfa89d2d8af8a1c608ed6e2e3e81c533dad146dead0385ae907f51ea3e658&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-raml.zip",
+                            "md5": "37af3559a8bdcdb08b3421feb8b057b2",
+                            "sha1": "ec47d4eec40658202701c45496faad34b4e22db7",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/a0cdbe36038ca4d4c2aac7ce4ad38808dd72dd07fadf16e0001e935bee4f1088.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=c64f6e230a413f1213f26d1bc32cb32158c92b58a4ab66dda8e400c695b0fa16&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-oas.zip",
+                            "md5": "0dfd5920d7ad906825878617b495cb73",
+                            "sha1": "ad7b5cf76f5b82cea2c61e65832998ec7abed85e",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d2a215de025c961c1179295ad5d34eb29ccb4dc80f58439d99a18b7b63618fb0.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=5d33e6f93341ce7df6f115ad5d69562f9d692d1331b3a1c1acb62e9e2135feed&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-raml.zip",
+                            "md5": "37af3559a8bdcdb08b3421feb8b057b2",
+                            "sha1": "ec47d4eec40658202701c45496faad34b4e22db7",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e72bcab5261d8dff96947993003ab195737aadab74230453d7d0f33ea8883ba2.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=36c2be1546bccedd5d800a57ca1d550f60476961fe8d5fd3c32aaa23da71eff3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2.pom",
+                            "md5": "a3ad55c7432b6ba799b62e7b09424900",
+                            "sha1": "cb67725209e512b3aa9668cc446d135f802911e0",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v1",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v1"
+                    }
+                }
+            ]
+        }
+    ],
+    "versionGroups": [
+        {
+            "productAPIVersion": "v2",
+            "versionGroup": "v2",
+            "versions": [
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "2.0.10",
+                    "versionGroup": "v2",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-05-13T11:58:36.817Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v2",
+                    "tags": [
+                        {
+                            "value": "v2",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/cd04e0c380473d835aecb8a70620fc0ea8419183c3b0641bb5ce8155c79df2f6.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=fb275580ad6ea62c9e920d5460ddcaaf0b154d40a9f89d5ab054c16e98a57a37&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-fat-oas.zip",
+                            "md5": "ada35173b56a437065c8f800d5e81ed9",
+                            "sha1": "a1940e69341abf621de11560e6d50e82e04edbff",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/18c647244a109642cd34158cb9ec8cfd41669d3b5d0d834b6dce934efaa506fc.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=37c6b9a882182853998a78ff61fefc2082a0b6731d84bea3b2362e4a1a3420c8&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-raml.zip",
+                            "md5": "fe5324c06fe37a956f456cf42d1b5f6c",
+                            "sha1": "c1f06316c1636532c19bb5cf671898b05e044160",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/915c38ad237750bd40286ca87bd08c87153070cd2dacb40e87dde2855424ef8b.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=25d3ac7495e1bbe22e331cd1c8b833e8919e3256e3caa65a36c3f6d1436efbb5&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-oas.zip",
+                            "md5": "f7d2fdb1cfad6fe3778b41c9ed5eb574",
+                            "sha1": "60453de2098a76972d080fe0f09c7df7ec44eb72",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/13c565a4a4820b23a523598ddd6659cb869b04010df2d8510201117c81cd99a9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=be7b47a5e5aaaf1b5f60ed19a7b4befd2ff1e49aeee73105aa68bd9743cb0ce3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-raml.zip",
+                            "md5": "fe5324c06fe37a956f456cf42d1b5f6c",
+                            "sha1": "c1f06316c1636532c19bb5cf671898b05e044160",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/107c75b5a52bf1a30a69e028c1cd5810af94632987c7f88cfb441a8e58ab082b.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=006026c16fb79806768b39e5083f0a8e5550ce482723ef7bd5d0d7ff6ecb6205&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10.pom",
+                            "md5": "b15ac1d4876def164f7b89c8c4b7a8d2",
+                            "sha1": "11c9c6ef2b8305a3feb5936172b753deeb874259",
+                            "createdDate": "2025-05-13T11:58:35.722Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v2",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v2"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b3",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "2.0.10-kbode.W-17297521-b3",
+                    "versionGroup": "v2",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-26T09:12:53.918Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v2",
+                    "tags": [
+                        {
+                            "value": "v2",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/f40cd797e4a8c0ba1db1be7e973ec6635638d794d6111b9c973a8a2a6dcf8226.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=74a407335d32aa22f9d1b2def32dad3dcb6299ee9e39044222a43d16175a6cce&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-fat-oas.zip",
+                            "md5": "a71a0b82b459ceed42cc1c49d328379a",
+                            "sha1": "376d684f6c205a6d08d4aa6198a2c2dc5ede8fbb",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/94f967d41453cc44195a9c7ae6f343f5a85193863a658710d576cbf65723167d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3b14730b13d1c3a3c13310a656f214c51b4ed59a1abcb6b9176fa982694eb1b1&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+                            "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+                            "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8a1cee0a20be38a9a6a6c2b458ad67878a87436d959d1c762d1800a1f5669903.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3dc2f54fa2c44ac46f421ba43926a6e5bac551578e5e6f5624da672c9223a06d&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-oas.zip",
+                            "md5": "ec67c7696d3fc2ba907dece2123834fe",
+                            "sha1": "d7c3a48b9f0924f494a772b1c4a72ddbdfb8f835",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/4c23b2a0f569e65ca8de6eab991ca1cd2e246c60b0f095881938ad8e0433ddb9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a275f1b126ee35233a0af531cc339ef0b9d303e831693a50f3879bef32ff292c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3-raml.zip",
+                            "md5": "95d9e16759f9fe7bc92aadf3636b06c0",
+                            "sha1": "f173e7cf6512e50573f241350e1c9e424e2e7dc1",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/b7ce5f10043dc6658a0b1477776d7a5f8da265383e3fe9af5ac794581d9e7889.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=d2f3c1237329d60d7ba2e860526996b9c4ee10518037b8a464ef7d58e2276dc3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b3.pom",
+                            "md5": "2b29fde033f578406927423961bb2066",
+                            "sha1": "749d7d48c49bcd76a6ad2b993fa7efba47feea57",
+                            "createdDate": "2025-03-26T09:12:52.646Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v2",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v2"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b2",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "2.0.10-kbode.W-17297521-b2",
+                    "versionGroup": "v2",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-24T10:51:34.76Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v2",
+                    "tags": [
+                        {
+                            "value": "v2",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v2",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/dfdebb0e29634d6924cf3b690f194387a716327def89597114a33b9a9e998e64.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=63cd5e97ed8a7a0377f2a6a303eae9fa475a05241514eaf153f848b12ad23874&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-fat-oas.zip",
+                            "md5": "16baf95635d92057d5eb19d386a460e2",
+                            "sha1": "58aa7f6cf922b22fcd0c69c80d8f07053268f0e3",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e8f1b3707a957472bc2960d9ea0879ab826d268c2e875bbab0020cb6ffcb4af2.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=0f6afd84b2d17240163b42da36fc2fbdac35ee65d414740ba8d1d69884f45bcf&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-raml.zip",
+                            "md5": "86b19905f8219baa22db881b897c8ac1",
+                            "sha1": "de22d1d127fa2cbefe5740d98fdaae0bc2d3ea71",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e081cc5bfbab190e3ac72d2ed11cf25c4239fd25df0a5e692ef7d3f5747015a3.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=4573925e5c43367d0ad11154eb618051c20d23a0fc4739ba160fd1922ef2a405&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-oas.zip",
+                            "md5": "2ffd3c27cc2e16087f869efb5793c43d",
+                            "sha1": "5d584704e8833c50eea497a6b9c4c9c14b84c7fd",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": "shopper-baskets-oas-v2-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e52b7946205522162fdd3906ceeac2dd86664811d04d6236d24738dcc240d136.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=477f71ce5600c5c978e4819d97a1abe513ed59f20517cf49bdb9a6e6afb512ac&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2-raml.zip",
+                            "md5": "86b19905f8219baa22db881b897c8ac1",
+                            "sha1": "de22d1d127fa2cbefe5740d98fdaae0bc2d3ea71",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/8358364b5c387cb3b69ed4576a7ea0cd08a1fb0d1ef8fde1012b04612dbf17d7.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=dd74b35d5c0fafe272f316f404e3a7a842b2983dc0b5304cd433250a8f7fd147&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-2.0.10-kbode.W-17297521-b2.pom",
+                            "md5": "e303dd91961754431f199184d3d00fae",
+                            "sha1": "ed9509564b70427bcce93e54f11ead3040d1dfa0",
+                            "createdDate": "2025-03-24T10:51:33.641Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v2",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v2"
+                    }
+                }
+            ]
+        },
+        {
+            "productAPIVersion": "v1",
+            "versionGroup": "v1",
+            "versions": [
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "1.8.19",
+                    "versionGroup": "v1",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-05-13T11:57:17.184Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v1",
+                    "tags": [
+                        {
+                            "value": "v1",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d5bef51f10a847071fa496fdcfae8ad5c6d6e8f498c8e209a84f354740043a66.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=ef579e987bc21af5572b66208fe2a539af5c279d930833ef732a735291958ebd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-fat-oas.zip",
+                            "md5": "2da51103d9c77a0e5572ccb82ddb8e20",
+                            "sha1": "127e30af830ab8ab080be0fc87c7fb7a9c932d25",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/88b43a90ad29b5dc6b60597c873d92ccf77b5c1c7104e9a47bd445e3b8be54c1.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=2a5c21c7cff82753d98897676838109aefb7087f3ad60fcf4d421ce688f51b6f&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-raml.zip",
+                            "md5": "cc9f2c0d09f59fc3cd3219f85a87d77c",
+                            "sha1": "63615356d049b5cbc7895d293a31375b4c378a4e",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/7cdcd0f4d3935c261e25c0242e3db7c15223a4186aa3b328718a088179c9c5d9.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=7c4960128274748691f0e6d43a95d6625f6974c03bf17fa015c829c5e4709cd4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-oas.zip",
+                            "md5": "feac43bd06bb9809740405f1a7403bbd",
+                            "sha1": "f8f65b58c46950edc4b9b67d0448fc75debaa23a",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/acf63889e419774fc9fa957d4453a4c52547dc717a59197884526ed23f6c7a52.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=3ca543f09ef4944cca28e50545d5aa57465d3b6bcd0d220df8e934da06f318ad&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-raml.zip",
+                            "md5": "cc9f2c0d09f59fc3cd3219f85a87d77c",
+                            "sha1": "63615356d049b5cbc7895d293a31375b4c378a4e",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/3e9c87c4c3d4c79fdb92f138decdad74c836f9d0455df83ce654207f7af9af3b.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=345cbb79878214fcb419d49048919b8b6de82faf1c0bbf52286048055e21ce42&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19.pom",
+                            "md5": "e2976a1b85670fac4941b0a8f4292f79",
+                            "sha1": "77cbd98a1c18604de17e77b3be45b210d94118a2",
+                            "createdDate": "2025-05-13T11:57:16.155Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v1",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v1"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19-kbode.W-17297521-b3",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "1.8.19-kbode.W-17297521-b3",
+                    "versionGroup": "v1",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-26T09:11:40.752Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v1",
+                    "tags": [
+                        {
+                            "value": "v1",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/56e8920dd018373d3eda2ca14cfc4bddc653ddf4ed91f3219d2ec7bde2f9f369.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=a91fe90a5e7b6bb8939ea6913826e1d43b3b3c3e98622395aba865b7c4b79f9b&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-fat-oas.zip",
+                            "md5": "a96d6a5244e97e3c3ec343a0e957b451",
+                            "sha1": "d310da36c7d7899fe26a913035e2c399393652f1",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/5c6dab15239773d33bdd8737b3785e0848780eb4bafa911f62e892f8f748b2b7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=c941ebea0cd76940dfbcd5e5626d53c4f268187eb4dc331819b81a0700ff2855&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-raml.zip",
+                            "md5": "df9c16d7b4c1ee851f59aa8eda06e700",
+                            "sha1": "2eee899a783f1ea9d56f8424b563a59b1163db88",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/035523f6f7093d03d95a0d43363fd041d867ef3ada40be7f071f1ede50e8de5d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=1b2636877832cc94558c3feee69fb5cf37448c262acd55696cb3fb56966201dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-oas.zip",
+                            "md5": "1425e130544dc906af818f652e5c6499",
+                            "sha1": "22a594b37cdfe95467ce807cbff8f46542919a6a",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/c30f5d398602bf61635d2588ef0287dbfd3ddf50005ca3a8c9268e44c7d64b2c.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=334162d08ee72cbedfec2f8ef01e245811438cc3915cf37d6838dcce1a70b9e2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3-raml.zip",
+                            "md5": "df9c16d7b4c1ee851f59aa8eda06e700",
+                            "sha1": "2eee899a783f1ea9d56f8424b563a59b1163db88",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/db8e4266d80ab156cae10bc3d83037130828514296054314fb9ac27494e97c86.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=9f64539adfe2788d7ebc29920a44bd867d98bca18a93da9395f0bac81896a7c7&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b3.pom",
+                            "md5": "7924db14708cb0cc12dcc51cd25b460c",
+                            "sha1": "4244b77b5eca1b1e08359e9360684ee60e38a996",
+                            "createdDate": "2025-03-26T09:11:39.513Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v1",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v1"
+                    }
+                },
+                {
+                    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/1.8.19-kbode.W-17297521-b2",
+                    "type": "rest-api",
+                    "groupId": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+                    "assetId": "shopper-baskets-oas",
+                    "version": "1.8.19-kbode.W-17297521-b2",
+                    "versionGroup": "v1",
+                    "organization": {
+                        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8"
+                    },
+                    "name": "Shopper Baskets OAS",
+                    "status": "published",
+                    "isPublic": false,
+                    "isSnapshot": false,
+                    "createdAt": "2025-03-24T10:50:14.021Z",
+                    "assetLink": "",
+                    "runtimeVersion": "",
+                    "productAPIVersion": "v1",
+                    "tags": [
+                        {
+                            "value": "v1",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "labels": [],
+                    "attributes": [
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "api-version"
+                        },
+                        {
+                            "value": "raml",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "rest",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "api",
+                            "tagType": "attribute",
+                            "key": null
+                        },
+                        {
+                            "value": "oas",
+                            "tagType": "attribute",
+                            "key": "original-format"
+                        },
+                        {
+                            "value": "3.0",
+                            "tagType": "attribute",
+                            "key": "original-format-version"
+                        },
+                        {
+                            "value": "v1",
+                            "tagType": "attribute",
+                            "key": "product-api-version"
+                        }
+                    ],
+                    "files": [
+                        {
+                            "classifier": "fat-oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/ab69f8eecaa790ffad2166db4fb55fbfd018ed84b853606ba840b631542f83cb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=14870b961ea33d2fb41a54c6c301b57c6d462b92e05cfe43a5ed5de2b6ba285a&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-fat-oas.zip",
+                            "md5": "2e7d8060621c7170c8e6dec8e77b186f",
+                            "sha1": "ba1f53803881bb4cae6c990f1c0c640c29a0f87f",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "fat-raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d01df14550047d0caf07b112ad3a00224ed6e868f7ec0cd5888e1e06b84431ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=013dfa89d2d8af8a1c608ed6e2e3e81c533dad146dead0385ae907f51ea3e658&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-raml.zip",
+                            "md5": "37af3559a8bdcdb08b3421feb8b057b2",
+                            "sha1": "ec47d4eec40658202701c45496faad34b4e22db7",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": "oas",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/a0cdbe36038ca4d4c2aac7ce4ad38808dd72dd07fadf16e0001e935bee4f1088.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=c64f6e230a413f1213f26d1bc32cb32158c92b58a4ab66dda8e400c695b0fa16&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-oas.zip",
+                            "md5": "0dfd5920d7ad906825878617b495cb73",
+                            "sha1": "ad7b5cf76f5b82cea2c61e65832998ec7abed85e",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": "shopper-baskets-oas-v1-bundled.yaml",
+                            "isGenerated": false
+                        },
+                        {
+                            "classifier": "raml",
+                            "packaging": "zip",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/d2a215de025c961c1179295ad5d34eb29ccb4dc80f58439d99a18b7b63618fb0.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=5d33e6f93341ce7df6f115ad5d69562f9d692d1331b3a1c1acb62e9e2135feed&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2-raml.zip",
+                            "md5": "37af3559a8bdcdb08b3421feb8b057b2",
+                            "sha1": "ec47d4eec40658202701c45496faad34b4e22db7",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": null,
+                            "isGenerated": true
+                        },
+                        {
+                            "classifier": null,
+                            "packaging": "pom",
+                            "externalLink": "https://exchange2-asset-manager-kprod.s3.amazonaws.com/893f605e-10e2-423a-bdb4-f952f56eb6d8/e72bcab5261d8dff96947993003ab195737aadab74230453d7d0f33ea8883ba2.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAVQT2Q7OAHAQKTX36%2F20250606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250606T025326Z&X-Amz-Expires=86400&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHsaCXVzLWVhc3QtMSJGMEQCIGBJInZ5jjR%2FMzIqsFPJQ27JadRGgRNG7KfsssZD%2BIFdAiBxyAyJfVD1uEWK0%2B5nbeu2mL9EMjc5HGgjb97ItVk3PiqxAghUEAMaDDM3OTI4NzgyOTM3NiIMFfsQ%2BjknoRKEG%2BreKo4CpvMR%2FmbPeYDDyYzx%2BY3rB39BkY5LquQUSy3pqVdN9gdL5rCQ26%2BoobyxMdRrY3KviDFdkhBib5yfF%2BdcdLE4acesTBx8xIa0VAETJlAkIjdfXMkS%2FA9%2BMLzd7wCmYn7xUA4xTrKuWFTqf4zAoieqfyyyHPZHIuo2O0Py6RYnmif7lEBOVFxMtV4X%2BoooI28lBCvj46Z8zoarDDO9y4XWEP0LBMKQrNcfVGCY3I0FlF%2BbJcv9kueqDHF0gNNT6Fliuaw%2BCc8v0VTf1r63SJVeM67IrtzHx6HhCKosmbjFRq2e8K3zuUiUX0945yie2DUIUVYyOoyk10N3Hv4bXCyn8xvu688i4BR3R%2FDNnM8PMOOjicIGOp4B0VXIlaKvXoHgG831mdPIomI%2FfnpCsM4yXSF5Z6%2BtLr6OfoQWAN8LMCZ%2B3te5yWx3896gAnLF9icBs7saapYyZP6GQYJMZTdrVVFI2ssAOQbw2j0XESV1HWN3%2BlqNvL9tfXJtqKr3yOhg%2F2b3zu6kPpbP1WGVqejpWkR%2Fu7D9EgzRyzoKtLudw0jUQEjKjc%2BHqIQaIx3BBNTqvRUbasg%3D&X-Amz-Signature=36c2be1546bccedd5d800a57ca1d550f60476961fe8d5fd3c32aaa23da71eff3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dshopper-baskets-oas-1.8.19-kbode.W-17297521-b2.pom",
+                            "md5": "a3ad55c7432b6ba799b62e7b09424900",
+                            "sha1": "cb67725209e512b3aa9668cc446d135f802911e0",
+                            "createdDate": "2025-03-24T10:50:12.974Z",
+                            "mainFile": null,
+                            "isGenerated": false
+                        }
+                    ],
+                    "metadata": {
+                        "apiVersion": "v1",
+                        "originalFormat": "oas",
+                        "originalFormatVersion": "3.0",
+                        "productApiVersion": "v1"
+                    }
+                }
+            ]
+        }
+    ],
+    "organization": {
+        "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8",
+        "name": "Commerce Cloud",
+        "parentOrganizationIds": [
+            "1c4670d0-9ee9-4d47-9246-ab7b50991599"
+        ],
+        "subOrganizationIds": [],
+        "tenantOrganizationIds": [],
+        "isMaster": false,
+        "isRoot": false,
+        "domain": "salesforcetmp",
+        "isMulesoftOrganization": false
+    },
+    "id": "893f605e-10e2-423a-bdb4-f952f56eb6d8/shopper-baskets-oas/2.0.10-kbode.W-17297521-b3",
+    "icon": null,
+    "modifiedAt": "2025-05-13T11:58:35.722Z",
+    "metadata": {
+        "apiVersion": "v2",
+        "originalFormat": "oas",
+        "originalFormatVersion": "3.0",
+        "productApiVersion": "v2"
+    },
+    "permissions": [
+        "edit"
+    ]
+}


### PR DESCRIPTION
@W-18706176 @W-18763414

1. Get latest version form all the version groups (V1, V2) of an API. This is to suuport Shopper Baskets V1 and V2
2. Remove the deprecated deployment flag
3. Added tests exchangeDirectoryParser to meet the coverage threshold
4. Spilt the test for exchangeDownloader.ts as there is a warning on the file size
5. All the code is behind isOas flag

Testing

1. download command
`node bin/run download --dest=raml-test --search='category:Visibility = "External"' --log-level=debug `

2. ran updateApis script in commerce-isomorphic-sdk