### PR TITLE
@W-17701719@ Allow more flags to be set for openapi generator

### DIFF
--- a/src/generate-from-oas/generateFromOas.ts
+++ b/src/generate-from-oas/generateFromOas.ts
@@ -33,6 +33,7 @@ export const generateFromOas = (args: {
   configFile?: string;
   generator?: string;
   skipValidateSpec?: boolean;
+  flags?: string;
 }) => {
   const {
     inputSpec,
@@ -41,12 +42,13 @@ export const generateFromOas = (args: {
     configFile,
     generator,
     skipValidateSpec,
+    flags,
   } = args;
   const skipValidateSpecFlag = skipValidateSpec ? "--skip-validate-spec" : "";
   const _configFile = configFile ? configFile : DEFAULT_CONFIG_PATH;
   const _generator = generator ? generator : "typescript-fetch";
 
   execSync(
-    `openapi-generator-cli generate -i ${inputSpec} -o ${outputDir} -t ${templateDir} -g ${_generator} -c ${_configFile} ${skipValidateSpecFlag}`
+    `openapi-generator-cli generate -i ${inputSpec} -o ${outputDir} -t ${templateDir} -g ${_generator} -c ${_configFile} ${skipValidateSpecFlag} ${flags}`
   );
 };

--- a/src/generate-from-oas/generateFromOas.ts
+++ b/src/generate-from-oas/generateFromOas.ts
@@ -47,8 +47,9 @@ export const generateFromOas = (args: {
   const skipValidateSpecFlag = skipValidateSpec ? "--skip-validate-spec" : "";
   const _configFile = configFile ? configFile : DEFAULT_CONFIG_PATH;
   const _generator = generator ? generator : "typescript-fetch";
+  const _flags = flags ? flags : "";
 
   execSync(
-    `openapi-generator-cli generate -i ${inputSpec} -o ${outputDir} -t ${templateDir} -g ${_generator} -c ${_configFile} ${skipValidateSpecFlag} ${flags}`
+    `openapi-generator-cli generate -i ${inputSpec} -o ${outputDir} -t ${templateDir} -g ${_generator} -c ${_configFile} ${skipValidateSpecFlag} ${_flags}`
   );
 };


### PR DESCRIPTION
Small change to allow the passing of more arguments to openapi-generator.

Required by the node-sdk so we can set `--reserved-words-mappings delete=delete`