### PR TITLE
W 18764378/oasdiff on multi vers of api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "max-lines": [
       "error",
       {
-        "max": 600
+        "max": 700
       }
     ],
     "@typescript-eslint/naming-convention": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "max-lines": [
       "error",
       {
-        "max": 700
+        "max": 500
       }
     ],
     "@typescript-eslint/naming-convention": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "max-lines": [
       "error",
       {
-        "max": 500
+        "max": 600
       }
     ],
     "@typescript-eslint/naming-convention": [

--- a/src/diff/diffCommand.test.ts
+++ b/src/diff/diffCommand.test.ts
@@ -13,7 +13,7 @@ import { Rule } from "json-rules-engine";
 import chai from "chai";
 import chaiFs from "chai-fs";
 
-import { DiffCommand as cmd, DiffCommand } from "./diffCommand";
+import { DiffCommand as cmd } from "./diffCommand";
 import * as diffDirectories from "./diffDirectories";
 import { NodeChanges } from "./changes/nodeChanges";
 import { ApiChanges } from "./changes/apiChanges";
@@ -24,10 +24,8 @@ import { RuleCategory } from "./ruleCategory";
 import * as oasDiff from "./oasDiff";
 
 import proxyquire from "proxyquire";
-import sinon from "sinon";
 
 chai.use(chaiFs);
-const pq = proxyquire.noCallThru();
 
 const nodeChanges = new NodeChanges("test-id", ["test:type"]);
 nodeChanges.added = { "core:name": "oldName" };

--- a/src/diff/diffCommand.test.ts
+++ b/src/diff/diffCommand.test.ts
@@ -23,8 +23,6 @@ import { CategorizedChange } from "./changes/categorizedChange";
 import { RuleCategory } from "./ruleCategory";
 import * as oasDiff from "./oasDiff";
 
-import proxyquire from "proxyquire";
-
 chai.use(chaiFs);
 
 const nodeChanges = new NodeChanges("test-id", ["test:type"]);

--- a/src/diff/oasDiff.test.ts
+++ b/src/diff/oasDiff.test.ts
@@ -123,6 +123,7 @@ describe("oasDiffChangelog", () => {
     consoleErrorSpy.restore();
   });
   it("should return error code 2 when no exchange.json files are found", async () => {
+    const consoleWarnSpy = sinon.spy(console, "warn");
     const execStub = createMockExec();
     const fsStub = createMockFs();
 
@@ -142,8 +143,10 @@ describe("oasDiffChangelog", () => {
     expect(result).to.equal(2);
     expect(consoleErrorSpy.called).to.be.true;
     expect(consoleErrorSpy.args[0][0].message).to.include(
-      "No exchange.json file found in leaf directory: base/api-v1"
+      "No exchange.json files found in any directory under: base"
     );
+
+    consoleWarnSpy.restore();
   });
 
   it("should return error code 2 when no exchange.json files are found in entire directory tree", async () => {
@@ -163,7 +166,7 @@ describe("oasDiffChangelog", () => {
     expect(result).to.equal(2);
     expect(consoleErrorSpy.called).to.be.true;
     expect(consoleErrorSpy.args[0][0].message).to.include(
-      "No exchange.json file found in leaf directory: base. Each API directory must contain an exchange.json file."
+      "No exchange.json files found in any directory under: base. Each API directory must contain an exchange.json file."
     );
   });
 

--- a/src/diff/oasDiff.test.ts
+++ b/src/diff/oasDiff.test.ts
@@ -35,7 +35,9 @@ describe("oasDiffChangelog", () => {
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
     expect(execSyncStub.called).to.be.true;
-    expect(execSyncStub.args[1][0]).to.equal('oasdiff changelog  "base.yaml" "new.yaml"');
+    expect(execSyncStub.args[1][0]).to.equal(
+      'oasdiff changelog  "base.yaml" "new.yaml"'
+    );
     expect(result).to.equal(0);
   });
 
@@ -122,7 +124,7 @@ describe("oasDiffChangelog", () => {
   it("should run oasdiff in directory mode when the --dir flag is provided", async () => {
     const execSyncStub = sinon.stub();
     execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("a change");
+    execSyncStub.onCall(1).returns("a minor change");
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1"]),
@@ -172,6 +174,7 @@ describe("oasDiffChangelog", () => {
     const newApi = "new";
     const flags = {
       "out-file": "output.txt",
+      dir: true,
     };
 
     await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
@@ -208,6 +211,7 @@ describe("oasDiffChangelog", () => {
     const flags = {
       "out-file": "output.json",
       format: "json",
+      dir: true,
     };
 
     await oasDiff.oasDiffChangelog(baseApi, newApi, flags);

--- a/src/diff/oasDiff.test.ts
+++ b/src/diff/oasDiff.test.ts
@@ -11,15 +11,21 @@ import sinon from "sinon";
 const pq = proxyquire.noCallThru();
 
 describe("oasDiffChangelog", () => {
-  it("should execute oasdiff command with correct parameters", async () => {
-    const stub = sinon.stub();
-    stub.onCall(0).returns("version 1.0.0");
-    stub.onCall(1).returns("");
+  it("should execute oasdiff command with correct parameters for single file mode", async () => {
+    const execSyncStub = sinon.stub();
+    execSyncStub.onCall(0).returns("version 1.0.0"); // version check
+    execSyncStub.onCall(1).returns(""); // diff result
+
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+    };
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: stub,
+        execSync: execSyncStub,
       },
+      "fs-extra": fsStub,
     });
 
     // Arrange
@@ -28,7 +34,36 @@ describe("oasDiffChangelog", () => {
     const flags = {};
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    expect(stub.called).to.be.true;
+    expect(execSyncStub.called).to.be.true;
+    expect(execSyncStub.args[1][0]).to.equal('oasdiff changelog  "base.yaml" "new.yaml"');
+    expect(result).to.equal(0);
+  });
+
+  it("should execute oasdiff command with correct parameters for directory mode", async () => {
+    const execSyncStub = sinon.stub();
+    execSyncStub.onCall(0).returns("version 1.0.0"); // version check
+    execSyncStub.onCall(1).returns(""); // diff result
+
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+    };
+
+    const oasDiff = pq("./oasDiff", {
+      child_process: {
+        execSync: execSyncStub,
+      },
+      "fs-extra": fsStub,
+    });
+
+    // Arrange
+    const baseApi = "base";
+    const newApi = "new";
+    const flags = { dir: true };
+    const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
+
+    expect(execSyncStub.called).to.be.true;
+    expect(execSyncStub.args[1][0]).to.include('"base/api-v1/**/*.yaml"');
     expect(result).to.equal(0);
   });
 
@@ -37,15 +72,20 @@ describe("oasDiffChangelog", () => {
     execSyncStub.onCall(0).returns("version 1.0.0");
     execSyncStub.onCall(1).returns("mock oasdiff change");
 
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+    };
+
     const oasDiff = pq("./oasDiff", {
       child_process: {
         execSync: execSyncStub,
       },
+      "fs-extra": fsStub,
     });
 
-    // Arrange
-    const baseApi = "base.yaml";
-    const newApi = "new.yaml";
+    const baseApi = "base";
+    const newApi = "new";
     const flags = {};
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
@@ -58,15 +98,20 @@ describe("oasDiffChangelog", () => {
     execSyncStub.onCall(0).returns("version 1.0.0");
     execSyncStub.onCall(1).throws(new Error("mock oasdiff error"));
 
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+    };
+
     const oasDiff = pq("./oasDiff", {
       child_process: {
         execSync: execSyncStub,
       },
+      "fs-extra": fsStub,
     });
 
-    // Arrange
-    const baseApi = "base.yaml";
-    const newApi = "new.yaml";
+    const baseApi = "base";
+    const newApi = "new";
     const flags = {};
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
@@ -79,14 +124,20 @@ describe("oasDiffChangelog", () => {
     execSyncStub.onCall(0).returns("version 1.0.0");
     execSyncStub.onCall(1).returns("a change");
 
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+    };
+
     const oasDiff = pq("./oasDiff", {
       child_process: {
         execSync: execSyncStub,
       },
+      "fs-extra": fsStub,
     });
 
-    const baseApi = "base.yaml";
-    const newApi = "new.yaml";
+    const baseApi = "base";
+    const newApi = "new";
     const flags = {
       dir: true,
     };
@@ -94,61 +145,116 @@ describe("oasDiffChangelog", () => {
 
     expect(execSyncStub.called).to.be.true;
     expect(execSyncStub.args[1][0]).to.equal(
-      'oasdiff changelog  --composed "base.yaml/**/*.yaml" "new.yaml/**/*.yaml"'
+      'oasdiff changelog  --composed "base/api-v1/**/*.yaml" "new/api-v1/**/*.yaml"'
     );
   });
 
-  it("should save the changes to a file when the --out-file flag is provided", async () => {
+  it("should concatenate results from multiple directories in text format", async () => {
     const execSyncStub = sinon.stub();
     execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("a change");
-    const fsStub = sinon.stub();
+    execSyncStub.onCall(1).returns("changes in api-v1");
+    execSyncStub.onCall(2).returns("changes in api-v2");
+
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1", "api-v2"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+      writeFile: sinon.stub(),
+    };
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
         execSync: execSyncStub,
       },
-      "fs-extra": {
-        writeFile: fsStub,
-      },
+      "fs-extra": fsStub,
     });
 
-    // Arrange
-    const baseApi = "base.yaml";
-    const newApi = "new.yaml";
+    const baseApi = "base";
+    const newApi = "new";
     const flags = {
       "out-file": "output.txt",
     };
 
     await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
-    expect(fsStub.called).to.be.true;
+
+    expect(fsStub.writeFile.called).to.be.true;
+    const writtenContent = fsStub.writeFile.args[0][1];
+    expect(writtenContent).to.include("=== Changes in api-v1 ===");
+    expect(writtenContent).to.include("changes in api-v1");
+    expect(writtenContent).to.include("=== Changes in api-v2 ===");
+    expect(writtenContent).to.include("changes in api-v2");
   });
 
-  it("should save the changes to a jsonfile when the --out-file flag is provided and format is json", async () => {
+  it("should concatenate results from multiple directories in JSON format", async () => {
     const execSyncStub = sinon.stub();
     execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns('{"change": "a change"}');
-    const fsStub = sinon.stub();
+    execSyncStub.onCall(1).returns('{"changes": "in api-v1"}');
+    execSyncStub.onCall(2).returns('{"changes": "in api-v2"}');
+
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1", "api-v2"]),
+      stat: sinon.stub().returns({ isDirectory: () => true }),
+      writeJson: sinon.stub(),
+    };
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
         execSync: execSyncStub,
       },
-      "fs-extra": {
-        writeJson: fsStub,
-      },
+      "fs-extra": fsStub,
     });
 
-    // Arrange
-    const baseApi = "base.yaml";
-    const newApi = "new.yaml";
+    const baseApi = "base";
+    const newApi = "new";
     const flags = {
       "out-file": "output.json",
       format: "json",
     };
 
     await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
-    expect(fsStub.called).to.be.true;
+
+    expect(fsStub.writeJson.called).to.be.true;
+    const writtenContent = fsStub.writeJson.args[0][1];
+    expect(writtenContent).to.be.an("array").with.lengthOf(2);
+    expect(writtenContent[0]).to.deep.include({
+      changes: "in api-v1",
+      directory: "api-v1",
+    });
+    expect(writtenContent[1]).to.deep.include({
+      changes: "in api-v2",
+      directory: "api-v2",
+    });
+  });
+
+  it("should skip non-directory entries", async () => {
+    const execSyncStub = sinon.stub();
+    execSyncStub.onCall(0).returns("version 1.0.0");
+    execSyncStub.onCall(1).returns("changes in api-v1");
+
+    const fsStub = {
+      readdir: sinon.stub().returns(["api-v1", "not-a-dir.txt"]),
+      stat: sinon.stub(),
+      writeFile: sinon.stub(),
+    };
+    // First call for api-v1 returns isDirectory true
+    fsStub.stat.onCall(0).returns({ isDirectory: () => true });
+    // Second call for not-a-dir.txt returns isDirectory false
+    fsStub.stat.onCall(1).returns({ isDirectory: () => false });
+
+    const oasDiff = pq("./oasDiff", {
+      child_process: {
+        execSync: execSyncStub,
+      },
+      "fs-extra": fsStub,
+    });
+
+    const baseApi = "base";
+    const newApi = "new";
+    const flags = {};
+
+    await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
+
+    // Should only call execSync twice (once for version check, once for api-v1)
+    expect(execSyncStub.callCount).to.equal(2);
   });
 
   it("should throw an error if oasdiff is not installed", () => {

--- a/src/diff/oasDiff.test.ts
+++ b/src/diff/oasDiff.test.ts
@@ -11,6 +11,26 @@ import sinon from "sinon";
 const pq = proxyquire.noCallThru();
 
 describe("oasDiffChangelog", () => {
+  it("should throw an error if oasdiff is not installed", async () => {
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, new Error("oasdiff not installed"));
+
+    const oasDiff = pq("./oasDiff", {
+      child_process: {
+        exec: execStub,
+      },
+    });
+
+    try {
+      await oasDiff.checkOasDiffIsInstalled();
+      expect.fail("Expected function to throw an error");
+    } catch (error) {
+      expect(error.message).to.equal(
+        "oasdiff is not installed. Install oasdiff according to https://github.com/oasdiff/oasdiff#installation"
+      );
+    }
+  });
+
   it("should execute oasdiff command with correct parameters for single file mode", async () => {
     const execStub = sinon.stub();
     // Mock the callback-style exec function
@@ -618,25 +638,5 @@ describe("oasDiffChangelog", () => {
 
     expect(execStub.called).to.be.true;
     expect(result).to.equal(1); // Changes should be reported
-  });
-
-  it("should throw an error if oasdiff is not installed", async () => {
-    const execStub = sinon.stub();
-    execStub.callsArgWith(1, new Error("oasdiff not installed"));
-
-    const oasDiff = pq("./oasDiff", {
-      child_process: {
-        exec: execStub,
-      },
-    });
-
-    try {
-      await oasDiff.checkOasDiffIsInstalled();
-      expect.fail("Expected function to throw an error");
-    } catch (error) {
-      expect(error.message).to.equal(
-        "oasdiff is not installed. Install oasdiff according to https://github.com/oasdiff/oasdiff#installation"
-      );
-    }
   });
 });

--- a/src/diff/oasDiff.test.ts
+++ b/src/diff/oasDiff.test.ts
@@ -12,9 +12,10 @@ const pq = proxyquire.noCallThru();
 
 describe("oasDiffChangelog", () => {
   it("should execute oasdiff command with correct parameters for single file mode", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0"); // version check
-    execSyncStub.onCall(1).returns(""); // diff result
+    const execStub = sinon.stub();
+    // Mock the callback-style exec function
+    execStub.callsArgWith(1, null, "", ""); // version check
+    execStub.onSecondCall().callsArgWith(1, null, "", ""); // diff result
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1"]),
@@ -23,7 +24,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -34,17 +35,17 @@ describe("oasDiffChangelog", () => {
     const flags = {};
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    expect(execSyncStub.called).to.be.true;
-    expect(execSyncStub.args[1][0]).to.equal(
-      'oasdiff changelog  "base.yaml" "new.yaml"'
+    expect(execStub.called).to.be.true;
+    expect(execStub.args[1][0]).to.equal(
+      'oasdiff changelog "base.yaml" "new.yaml"'
     );
     expect(result).to.equal(0);
   });
 
   it("should execute oasdiff command with correct parameters for directory mode", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0"); // version check
-    execSyncStub.onCall(1).returns(""); // diff result
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", ""); // version check
+    execStub.onSecondCall().callsArgWith(1, null, "", ""); // diff result
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1"]),
@@ -53,7 +54,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -64,15 +65,15 @@ describe("oasDiffChangelog", () => {
     const flags = { dir: true };
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    expect(execSyncStub.called).to.be.true;
-    expect(execSyncStub.args[1][0]).to.include('"base/api-v1/**/*.yaml"');
+    expect(execStub.called).to.be.true;
+    expect(execStub.args[1][0]).to.include("base/api-v1/**/*.yaml");
     expect(result).to.equal(0);
   });
 
   it("should return 1 when oasdiff returns a non-empty string", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("mock oasdiff change");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, null, "mock oasdiff change", "");
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1"]),
@@ -81,7 +82,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -91,14 +92,14 @@ describe("oasDiffChangelog", () => {
     const flags = {};
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    expect(execSyncStub.called).to.be.true;
+    expect(execStub.called).to.be.true;
     expect(result).to.equal(1);
   });
 
   it("should return 2 when oasdiff throws an error", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).throws(new Error("mock oasdiff error"));
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, new Error("mock oasdiff error"));
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1"]),
@@ -107,7 +108,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -117,14 +118,14 @@ describe("oasDiffChangelog", () => {
     const flags = {};
     const result = await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    expect(execSyncStub.called).to.be.true;
+    expect(execStub.called).to.be.true;
     expect(result).to.equal(2);
   });
 
   it("should run oasdiff in directory mode when the --dir flag is provided", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("a minor change");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, null, "a minor change", "");
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1"]),
@@ -133,7 +134,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -145,17 +146,17 @@ describe("oasDiffChangelog", () => {
     };
     await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    expect(execSyncStub.called).to.be.true;
-    expect(execSyncStub.args[1][0]).to.equal(
-      'oasdiff changelog  --composed "base/api-v1/**/*.yaml" "new/api-v1/**/*.yaml"'
+    expect(execStub.called).to.be.true;
+    expect(execStub.args[1][0]).to.equal(
+      'oasdiff changelog --composed "base/api-v1/**/*.yaml" "new/api-v1/**/*.yaml"'
     );
   });
 
   it("should concatenate results from multiple directories in text format", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("changes in api-v1");
-    execSyncStub.onCall(2).returns("changes in api-v2");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, null, "changes in api-v1", "");
+    execStub.onThirdCall().callsArgWith(1, null, "changes in api-v2", "");
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1", "api-v2"]),
@@ -165,7 +166,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -188,10 +189,14 @@ describe("oasDiffChangelog", () => {
   });
 
   it("should concatenate results from multiple directories in JSON format", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns('{"changes": "in api-v1"}');
-    execSyncStub.onCall(2).returns('{"changes": "in api-v2"}');
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub
+      .onSecondCall()
+      .callsArgWith(1, null, '{"changes": "in api-v1"}', "");
+    execStub
+      .onThirdCall()
+      .callsArgWith(1, null, '{"changes": "in api-v2"}', "");
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1", "api-v2"]),
@@ -201,7 +206,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -230,9 +235,9 @@ describe("oasDiffChangelog", () => {
   });
 
   it("should skip non-directory entries", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("changes in api-v1");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, null, "changes in api-v1", "");
 
     const fsStub = {
       readdir: sinon.stub().returns(["api-v1", "not-a-dir.txt"]),
@@ -246,7 +251,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -257,13 +262,13 @@ describe("oasDiffChangelog", () => {
 
     await oasDiff.oasDiffChangelog(baseApi, newApi, flags);
 
-    // Should only call execSync twice (once for version check, once for api-v1)
-    expect(execSyncStub.callCount).to.equal(2);
+    // Should only call exec twice (once for version check, once for api-v1)
+    expect(execStub.callCount).to.equal(2);
   });
 
   it("should report deleted APIs when directories exist in base but not in new", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
 
     const fsStub = {
       readdir: sinon.stub(),
@@ -271,7 +276,7 @@ describe("oasDiffChangelog", () => {
       writeFile: sinon.stub(),
     };
 
-    // Base has api-v1 and api-v2, new only has api-v1
+    // Base has api-v1 and api-v2, new only has api-v2
     fsStub.readdir.onCall(0).returns(["api-v1", "api-v2"]); // base directories
     fsStub.readdir.onCall(1).returns(["api-v2"]); // new directories
 
@@ -280,7 +285,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -300,8 +305,8 @@ describe("oasDiffChangelog", () => {
   });
 
   it("should report added APIs when directories exist in new but not in base", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
 
     const fsStub = {
       readdir: sinon.stub(),
@@ -318,7 +323,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -338,9 +343,9 @@ describe("oasDiffChangelog", () => {
   });
 
   it("should report both added and deleted APIs in the same comparison", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("changes in api-v1");
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, null, "changes in api-v1", "");
 
     const fsStub = {
       readdir: sinon.stub(),
@@ -348,7 +353,7 @@ describe("oasDiffChangelog", () => {
       writeFile: sinon.stub(),
     };
 
-    // Base has api-v1 and api-v2, new has api-v1 and api-v3
+    // Base has api-v1 and api-v2, new has api-v2 and api-v3
     fsStub.readdir.onCall(0).returns(["api-v1", "api-v2"]); // base directories
     fsStub.readdir.onCall(1).returns(["api-v2", "api-v3"]); // new directories
 
@@ -357,7 +362,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -379,10 +384,10 @@ describe("oasDiffChangelog", () => {
   });
 
   it("should handle mixed scenarios with changes, additions, and deletions", async () => {
-    const execSyncStub = sinon.stub();
-    execSyncStub.onCall(0).returns("version 1.0.0");
-    execSyncStub.onCall(1).returns("changes in common-api");
-    execSyncStub.onCall(2).returns(""); // no changes in stable-api
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, null, "version 1.0.0", "");
+    execStub.onSecondCall().callsArgWith(1, null, "changes in common-api", "");
+    execStub.onThirdCall().callsArgWith(1, null, "", ""); // no changes in stable-api
 
     const fsStub = {
       readdir: sinon.stub(),
@@ -400,7 +405,7 @@ describe("oasDiffChangelog", () => {
 
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: execSyncStub,
+        exec: execStub,
       },
       "fs-extra": fsStub,
     });
@@ -431,15 +436,23 @@ describe("oasDiffChangelog", () => {
     expect(writtenContent).to.not.include("=== Changes in stable-api ===");
   });
 
-  it("should throw an error if oasdiff is not installed", () => {
+  it("should throw an error if oasdiff is not installed", async () => {
+    const execStub = sinon.stub();
+    execStub.callsArgWith(1, new Error("oasdiff not installed"));
+
     const oasDiff = pq("./oasDiff", {
       child_process: {
-        execSync: sinon.stub().throws(new Error("oasdiff not installed")),
+        exec: execStub,
       },
     });
 
-    expect(() => oasDiff.checkOasDiffIsInstalled()).to.throw(
-      "oasdiff is not installed. Install oasdiff according to https://github.com/oasdiff/oasdiff#installation"
-    );
+    try {
+      await oasDiff.checkOasDiffIsInstalled();
+      expect.fail("Expected function to throw an error");
+    } catch (error) {
+      expect(error.message).to.equal(
+        "oasdiff is not installed. Install oasdiff according to https://github.com/oasdiff/oasdiff#installation"
+      );
+    }
   });
 });

--- a/src/diff/oasDiff.ts
+++ b/src/diff/oasDiff.ts
@@ -103,7 +103,15 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
         // Check if matching directory doesn't exist in new
         if (!newDirectories.includes(baseDir)) {
           console.log(`${baseDir} API is deleted`);
-          allResults.push(`======${baseDir} API is deleted======`);
+          if (flags.format === "json") {
+            allResults.push({
+              directory: baseDir,
+              status: "deleted",
+              message: `${baseDir} API is deleted`,
+            });
+          } else {
+            allResults.push(`======${baseDir} API is deleted======`);
+          }
           hasChanges = true;
           continue;
         }
@@ -125,8 +133,12 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
             console.log(`Changes found in ${baseDir}`);
             if (flags.format === "json") {
               const outputJson = JSON.parse(oasdiffOutput);
-              outputJson.directory = baseDir;
-              allResults.push(outputJson);
+              if (outputJson.length) {
+                allResults.push({
+                  directory: baseDir,
+                  changes: outputJson,
+                });
+              }
             } else {
               // For text format, add section headers
               const formattedOutput = `=== Changes in ${baseDir} ===\n${oasdiffOutput}`;
@@ -154,7 +166,15 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
         // Check if this directory doesn't exist in base (added API)
         if (!baseDirectories.includes(newDir)) {
           console.log(`${newDir} API is added`);
-          allResults.push(`======${newDir} API is added======`);
+          if (flags.format === "json") {
+            allResults.push({
+              directory: newDir,
+              status: "added",
+              message: `${newDir} API is added`,
+            });
+          } else {
+            allResults.push(`======${newDir} API is added======`);
+          }
           hasChanges = true;
         }
       }
@@ -202,7 +222,7 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
 export async function checkOasDiffIsInstalled() {
   try {
     await new Promise<void>((resolve, reject) => {
-      exec(`oasdiff --version`, (error, stdout, stderr) => {
+      exec(`oasdiff --version`, (error) => {
         if (error) {
           reject(error);
         } else {

--- a/src/diff/oasDiff.ts
+++ b/src/diff/oasDiff.ts
@@ -17,12 +17,12 @@ import { execSync } from "child_process";
 async function _saveOrLogOas(changes: string, flags): Promise<void> {
   const file = flags["out-file"];
   if (file) {
-    console.log(`API Changes found! Saving results to file ${file}`);
+    console.log(`API Changes found! Saving results to file ${file}:`);
     if (flags.format === "json") {
-      console.log("Using json format");
+      console.log(`    using json format`);
       await fs.writeJson(file, JSON.parse(changes));
     } else {
-      console.log("Using console format");
+      console.log(`    using console format`);
       await fs.writeFile(file, changes);
     }
   } else {
@@ -82,12 +82,13 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
           if (oasdiffOutput.trim().length > 0) {
             console.log(`Changes found in ${baseDir}`);
             if (flags.format === "json") {
-              // For JSON format, parse the output and add to array
               const outputJson = JSON.parse(oasdiffOutput);
               outputJson.directory = baseDir;
               allResults.push(outputJson);
             } else {
-              allResults.push(oasdiffOutput);
+              // For text format, add section headers
+              const formattedOutput = `=== Changes in ${baseDir} ===\n${oasdiffOutput}`;
+              allResults.push(formattedOutput);
             }
             hasChanges = true;
           } else {

--- a/src/diff/oasDiff.ts
+++ b/src/diff/oasDiff.ts
@@ -4,9 +4,68 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/* eslint header/header: "off", max-lines:"off" */
+
 import fs from "fs-extra";
 import { exec } from "child_process";
 import path from "path";
+
+/**
+ * Interface for flags used in oasDiff functions
+ */
+interface OasDiffFlags {
+  format?: "json" | "console";
+  dir?: boolean;
+  "out-file"?: string;
+}
+
+/**
+ * Represents a directory-level API change (added/deleted)
+ */
+interface DirectoryStatusChange {
+  directory: string;
+  status: "added" | "deleted";
+  message: string;
+}
+
+/**
+ * Represents file-level changes within a directory
+ */
+interface FileChange {
+  file: string;
+  status: "added" | "deleted";
+  message: string;
+}
+
+/**
+ * Represents changes found in a directory with detailed change information
+ */
+interface DirectoryChanges {
+  directory: string;
+  changes: (FileChange | Record<string, unknown>)[];
+}
+
+/**
+ * Union type for all possible result items
+ * - string: Text format output
+ * - DirectoryStatusChange: JSON format for added/deleted directories
+ * - DirectoryChanges: JSON format for directories with file changes
+ * - unknown[]: Parsed JSON output from oasdiff (structure depends on oasdiff output)
+ */
+type OasDiffResult =
+  | string
+  | DirectoryStatusChange
+  | DirectoryChanges
+  | unknown[];
+
+/**
+ * Return type for oasDiff handler functions
+ */
+interface OasDiffHandlerResult {
+  results: OasDiffResult[];
+  hasChanges: boolean;
+  hasErrors: boolean;
+}
 
 /**
  * Recursively find directories containing exchange.json files
@@ -130,7 +189,10 @@ async function findYamlFiles(dirPath: string): Promise<string[]> {
  * @param changes - The changes to save or log
  * @param flags - Parsed CLI flags passed to the command
  */
-async function _saveOrLogOas(changes: string, flags): Promise<void> {
+async function _saveOrLogOas(
+  changes: string,
+  flags: OasDiffFlags
+): Promise<void> {
   const file = flags["out-file"];
   if (file) {
     console.log(`API Changes found! Saving results to file ${file}:`);
@@ -181,6 +243,221 @@ async function executeOasDiff(
 }
 
 /**
+ * Handle directory mode comparison logic
+ *
+ * @param baseApi - The base API directory
+ * @param newApi - The new API directory
+ * @param jsonMode - JSON formatting flag
+ * @param flags - CLI flags
+ * @returns Object containing results, hasChanges flag, and hasErrors flag
+ */
+async function handleDirectoryMode(
+  baseApi: string,
+  newApi: string,
+  jsonMode: string,
+  flags: OasDiffFlags
+): Promise<OasDiffHandlerResult> {
+  const allResults: OasDiffResult[] = [];
+  let hasChanges = false;
+  let hasErrors = false;
+
+  // Find all exchange.json files and their parent directories
+  const baseExchangeDirs = await findExchangeDirectories(baseApi);
+  const newExchangeDirs = await findExchangeDirectories(newApi);
+
+  const allDirNames = new Set([
+    ...baseExchangeDirs.map((dir) => dir.name),
+    ...newExchangeDirs.map((dir) => dir.name),
+  ]);
+
+  for (const dirName of allDirNames) {
+    const baseDir = baseExchangeDirs.find((dir) => dir.name === dirName);
+    const newDir = newExchangeDirs.find((dir) => dir.name === dirName);
+
+    // Check if directory was deleted
+    if (baseDir && !newDir) {
+      console.log(`${dirName} API is deleted`);
+      if (flags.format === "json") {
+        allResults.push({
+          directory: dirName,
+          status: "deleted",
+          message: `${dirName} API is deleted`,
+        });
+      } else {
+        allResults.push(`======${dirName} API is deleted======`);
+      }
+      hasChanges = true;
+      continue;
+    }
+
+    // Check if directory was added
+    if (!baseDir && newDir) {
+      console.log(`${dirName} API is added`);
+      if (flags.format === "json") {
+        allResults.push({
+          directory: dirName,
+          status: "added",
+          message: `${dirName} API is added`,
+        });
+      } else {
+        allResults.push(`======${dirName} API is added======`);
+      }
+      hasChanges = true;
+      continue;
+    }
+
+    // Both directories exist, compare individual yml files in each directory
+    if (baseDir && newDir) {
+      console.log("===================================");
+      console.log(`Processing directory pair: ${dirName}`);
+
+      try {
+        const baseYamlFiles = await findYamlFiles(baseDir.path);
+        const newYamlFiles = await findYamlFiles(newDir.path);
+
+        const directoryChanges: (FileChange | Record<string, unknown>)[] = [];
+        const directoryChangesText: string[] = [];
+
+        // Process each YAML file pair
+        for (const baseYamlFile of baseYamlFiles) {
+          const baseFileName = path.basename(baseYamlFile);
+          const newYamlFile = newYamlFiles.find(
+            (f) => path.basename(f) === baseFileName
+          );
+
+          if (newYamlFile) {
+            console.log(`Comparing ${baseFileName} in ${dirName}`);
+            const oasdiffOutput = await executeOasDiff(
+              baseYamlFile,
+              newYamlFile,
+              jsonMode
+            );
+
+            if (oasdiffOutput.trim().length > 0) {
+              if (flags.format === "json") {
+                const outputJson = JSON.parse(oasdiffOutput);
+                if (outputJson?.length > 0) {
+                  directoryChanges.push(...outputJson);
+                }
+              } else {
+                directoryChangesText.push(
+                  `--- Changes in ${baseFileName} ---\n${oasdiffOutput}`
+                );
+              }
+            }
+          } else {
+            console.log(`File ${baseFileName} was deleted in ${dirName}`);
+            if (flags.format === "json") {
+              directoryChanges.push({
+                file: baseFileName,
+                status: "deleted",
+                message: `File ${baseFileName} was deleted`,
+              });
+            } else {
+              directoryChangesText.push(
+                `--- File ${baseFileName} was deleted ---`
+              );
+            }
+          }
+        }
+
+        // Check for added files
+        for (const newYamlFile of newYamlFiles) {
+          const newFileName = path.basename(newYamlFile);
+          const baseYamlFile = baseYamlFiles.find(
+            (f) => path.basename(f) === newFileName
+          );
+
+          if (!baseYamlFile) {
+            console.log(`File ${newFileName} was added in ${dirName}`);
+            if (flags.format === "json") {
+              directoryChanges.push({
+                file: newFileName,
+                status: "added",
+                message: `File ${newFileName} was added`,
+              });
+            } else {
+              directoryChangesText.push(
+                `--- File ${newFileName} was added ---`
+              );
+            }
+          }
+        }
+
+        if (directoryChanges.length > 0 || directoryChangesText.length > 0) {
+          console.log(`Changes found in ${dirName}`);
+          if (flags.format === "json") {
+            allResults.push({
+              directory: dirName,
+              changes: directoryChanges,
+            });
+          } else {
+            const formattedOutput = `=== Changes in ${dirName} ===\n${directoryChangesText.join(
+              "\n"
+            )}`;
+            allResults.push(formattedOutput);
+          }
+          hasChanges = true;
+        } else {
+          console.log(`No changes found in ${dirName}`);
+        }
+      } catch (err) {
+        console.error(`Error processing ${dirName}:`, err);
+        hasErrors = true;
+      }
+    }
+  }
+
+  return { results: allResults, hasChanges, hasErrors };
+}
+
+/**
+ * Handle single file mode comparison logic
+ *
+ * @param baseApi - The base API file
+ * @param newApi - The new API file
+ * @param jsonMode - JSON formatting flag
+ * @param flags - CLI flags
+ * @returns Object containing results, hasChanges flag, and hasErrors flag
+ */
+async function handleSingleFileMode(
+  baseApi: string,
+  newApi: string,
+  jsonMode: string,
+  flags: OasDiffFlags
+): Promise<OasDiffHandlerResult> {
+  const allResults: OasDiffResult[] = [];
+  let hasChanges = false;
+  let hasErrors = false;
+
+  try {
+    const oasdiffOutput = await executeOasDiff(baseApi, newApi, jsonMode);
+
+    if (oasdiffOutput.trim().length > 0) {
+      console.log("Changes found");
+      if (flags.format === "json") {
+        // For JSON format, parse the output
+        const outputJson = JSON.parse(oasdiffOutput);
+        if (outputJson?.length > 0) {
+          allResults.push(outputJson);
+          hasChanges = true;
+        }
+      } else {
+        allResults.push(oasdiffOutput);
+        hasChanges = true;
+      }
+    } else {
+      console.log("No changes found");
+    }
+  } catch (err) {
+    console.error("Error processing files:", err);
+    hasErrors = true;
+  }
+
+  return { results: allResults, hasChanges, hasErrors };
+}
+
+/**
  * Wrapper for oasdiff changelog command.
  *
  * @param baseApi - The base API file or directory
@@ -188,199 +465,27 @@ async function executeOasDiff(
  * @param flags - Parsed CLI flags passed to the command
  * @returns 0 if no changes are reported, 1 if changes are reported, and 2 if an error occurs
  */
-export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
+export async function oasDiffChangelog(
+  baseApi: string,
+  newApi: string,
+  flags: OasDiffFlags
+) {
   try {
     await checkOasDiffIsInstalled();
     console.log("......Starting oasdiff......");
 
     const jsonMode = flags.format === "json" ? "-f json" : "";
 
-    let hasChanges = false;
-    let hasErrors = false;
-    const allResults = [];
-
-    // Handle directory mode
-    if (flags.dir) {
-      // Find all exchange.json files and their parent directories
-      const baseExchangeDirs = await findExchangeDirectories(baseApi);
-      const newExchangeDirs = await findExchangeDirectories(newApi);
-
-      const allDirNames = new Set([
-        ...baseExchangeDirs.map((dir) => dir.name),
-        ...newExchangeDirs.map((dir) => dir.name),
-      ]);
-
-      for (const dirName of allDirNames) {
-        const baseDir = baseExchangeDirs.find((dir) => dir.name === dirName);
-        const newDir = newExchangeDirs.find((dir) => dir.name === dirName);
-
-        // Check if directory was deleted
-        if (baseDir && !newDir) {
-          console.log(`${dirName} API is deleted`);
-          if (flags.format === "json") {
-            allResults.push({
-              directory: dirName,
-              status: "deleted",
-              message: `${dirName} API is deleted`,
-            });
-          } else {
-            allResults.push(`======${dirName} API is deleted======`);
-          }
-          hasChanges = true;
-          continue;
-        }
-
-        // Check if directory was added
-        if (!baseDir && newDir) {
-          console.log(`${dirName} API is added`);
-          if (flags.format === "json") {
-            allResults.push({
-              directory: dirName,
-              status: "added",
-              message: `${dirName} API is added`,
-            });
-          } else {
-            allResults.push(`======${dirName} API is added======`);
-          }
-          hasChanges = true;
-          continue;
-        }
-
-        // Both directories exist, compare them
-        if (baseDir && newDir) {
-          console.log("===================================");
-          console.log(`Processing directory pair: ${dirName}`);
-
-          try {
-            const baseYamlFiles = await findYamlFiles(baseDir.path);
-            const newYamlFiles = await findYamlFiles(newDir.path);
-
-            const directoryChanges = [];
-            const directoryChangesText = [];
-
-            // Process each YAML file pair
-            for (const baseYamlFile of baseYamlFiles) {
-              const baseFileName = path.basename(baseYamlFile);
-              const newYamlFile = newYamlFiles.find(
-                (f) => path.basename(f) === baseFileName
-              );
-
-              if (newYamlFile) {
-                console.log(`Comparing ${baseFileName} in ${dirName}`);
-                const oasdiffOutput = await executeOasDiff(
-                  baseYamlFile,
-                  newYamlFile,
-                  jsonMode
-                );
-
-                if (oasdiffOutput.trim().length > 0) {
-                  if (flags.format === "json") {
-                    const outputJson = JSON.parse(oasdiffOutput);
-                    if (outputJson?.length > 0) {
-                      directoryChanges.push(...outputJson);
-                    }
-                  } else {
-                    directoryChangesText.push(
-                      `--- Changes in ${baseFileName} ---\n${oasdiffOutput}`
-                    );
-                  }
-                }
-              } else {
-                console.log(`File ${baseFileName} was deleted in ${dirName}`);
-                if (flags.format === "json") {
-                  directoryChanges.push({
-                    file: baseFileName,
-                    status: "deleted",
-                    message: `File ${baseFileName} was deleted`,
-                  });
-                } else {
-                  directoryChangesText.push(
-                    `--- File ${baseFileName} was deleted ---`
-                  );
-                }
-              }
-            }
-
-            // Check for added files
-            for (const newYamlFile of newYamlFiles) {
-              const newFileName = path.basename(newYamlFile);
-              const baseYamlFile = baseYamlFiles.find(
-                (f) => path.basename(f) === newFileName
-              );
-
-              if (!baseYamlFile) {
-                console.log(`File ${newFileName} was added in ${dirName}`);
-                if (flags.format === "json") {
-                  directoryChanges.push({
-                    file: newFileName,
-                    status: "added",
-                    message: `File ${newFileName} was added`,
-                  });
-                } else {
-                  directoryChangesText.push(
-                    `--- File ${newFileName} was added ---`
-                  );
-                }
-              }
-            }
-
-            if (
-              directoryChanges.length > 0 ||
-              directoryChangesText.length > 0
-            ) {
-              console.log(`Changes found in ${dirName}`);
-              if (flags.format === "json") {
-                allResults.push({
-                  directory: dirName,
-                  changes: directoryChanges,
-                });
-              } else {
-                const formattedOutput = `=== Changes in ${dirName} ===\n${directoryChangesText.join(
-                  "\n"
-                )}`;
-                allResults.push(formattedOutput);
-              }
-              hasChanges = true;
-            } else {
-              console.log(`No changes found in ${dirName}`);
-            }
-          } catch (err) {
-            console.error(`Error processing ${dirName}:`, err);
-            hasErrors = true;
-          }
-        }
-      }
-    } else {
-      try {
-        const oasdiffOutput = await executeOasDiff(baseApi, newApi, jsonMode);
-
-        if (oasdiffOutput.trim().length > 0) {
-          console.log("Changes found");
-          if (flags.format === "json") {
-            // For JSON format, parse the output
-            const outputJson = JSON.parse(oasdiffOutput);
-            if (outputJson?.length > 0) {
-              allResults.push(outputJson);
-              hasChanges = true;
-            }
-          } else {
-            allResults.push(oasdiffOutput);
-            hasChanges = true;
-          }
-        } else {
-          console.log("No changes found");
-        }
-      } catch (err) {
-        console.error("Error processing files:", err);
-        hasErrors = true;
-      }
-    }
+    // Handle directory mode or single file mode
+    const { results, hasChanges, hasErrors } = flags.dir
+      ? await handleDirectoryMode(baseApi, newApi, jsonMode, flags)
+      : await handleSingleFileMode(baseApi, newApi, jsonMode, flags);
 
     if (hasChanges) {
       if (flags.format === "json") {
-        await _saveOrLogOas(JSON.stringify(allResults, null, 2), flags);
+        await _saveOrLogOas(JSON.stringify(results, null, 2), flags);
       } else {
-        await _saveOrLogOas(allResults.join("\n"), flags);
+        await _saveOrLogOas(results.join("\n"), flags);
       }
     }
 

--- a/src/diff/oasDiff.ts
+++ b/src/diff/oasDiff.ts
@@ -115,7 +115,7 @@ async function findExchangeDirectories(
       }
       // If this is a leaf directory and we haven't found exchange.json, that's an error
       if (subdirectories.length === 0 && !hasExchangeJson) {
-        throw new Error(
+        console.warn(
           `No exchange.json file found in leaf directory: ${currentPath}. Each API directory must contain an exchange.json file.`
         );
       }

--- a/src/diff/oasDiff.ts
+++ b/src/diff/oasDiff.ts
@@ -133,18 +133,19 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
             console.log(`Changes found in ${baseDir}`);
             if (flags.format === "json") {
               const outputJson = JSON.parse(oasdiffOutput);
-              if (outputJson.length) {
+              if (outputJson?.length > 0) {
                 allResults.push({
                   directory: baseDir,
                   changes: outputJson,
                 });
+                hasChanges = true;
               }
             } else {
               // For text format, add section headers
               const formattedOutput = `=== Changes in ${baseDir} ===\n${oasdiffOutput}`;
               allResults.push(formattedOutput);
+              hasChanges = true;
             }
-            hasChanges = true;
           } else {
             console.log(`No changes found in ${baseDir}`);
           }
@@ -187,11 +188,14 @@ export async function oasDiffChangelog(baseApi: string, newApi: string, flags) {
           if (flags.format === "json") {
             // For JSON format, parse the output
             const outputJson = JSON.parse(oasdiffOutput);
-            allResults.push(outputJson);
+            if (outputJson?.length > 0) {
+              allResults.push(outputJson);
+              hasChanges = true;
+            }
           } else {
             allResults.push(oasdiffOutput);
+            hasChanges = true;
           }
-          hasChanges = true;
         } else {
           console.log("No changes found");
         }

--- a/src/generate-from-oas/generateCommand.ts
+++ b/src/generate-from-oas/generateCommand.ts
@@ -10,7 +10,6 @@ import { allCommonFlags } from "../common/flags";
 import {
   generateFromOas,
   DEFAULT_CONFIG_PACKAGE_PATH,
-  DEFAULT_CONFIG_PATH,
 } from "./generateFromOas";
 
 export class GenerateCommand extends Command {

--- a/src/generate-from-oas/generateFromOas.ts
+++ b/src/generate-from-oas/generateFromOas.ts
@@ -7,7 +7,6 @@
 
 import path from "path";
 import { execSync } from "child_process";
-import { string, boolean } from "@oclif/parser/lib/flags";
 
 // Path relative to project root
 export const DEFAULT_CONFIG_BASE_PATH =


### PR DESCRIPTION
This PR fixed the oasdiff command to be compatible with multiple version of the same API. (E.g shopper-basket v2 and v1)
### Problem:
Since we are pulling multiple verserions of the same apis. Some of them will have the same endpoints. When we try to run `oasdiff changlog` on the parent directory (apis vs oldApis). We ran into an error of endpoint duplication.

### Solution
Loop through the each API folder and run oasdiff instead of the parent directory. This will guarantee there is not duplication in each run and concat the results into a txt file.


### How to test drive
- check out code
- npm i
- npm run build
- npm run test
- Observe all the tests are passing

### How to test the changes on isomorphic
- check out this oas branch for isomorphic https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/198
- Change raml-toolkit to locale dependencies
- `yarn ci`
- Make sure your node_modules has the raml-toolkit of your local 
- Run `npm run updateApis` twice to get the current api copied to oldApis folder
- Here two copies will be identical, you won't see much output in the diffApi.txt. Go to oldApis and randomly removed any endpoint from 2 api. E.g oldApis/shopper-basket-oas-1.8.19/shopper-basket-oas-v1-bundled.yaml. Removed end endpoint.  Do the same for shopper-basket-oas-2.x
- Run `yarn run diffApis` and observe the diffApis. You should see output look similiar to this. 
default format output
```
=== Changes in shopper-baskets-oas-1.8.19 ===
1 changes: 0 error, 0 warning, 1 info
info	[endpoint-added] at apis/shopper-baskets-oas-1.8.19/shopper-baskets-oas-v1-bundled.yaml	
	in API POST /organizations/{organizationId}/baskets
		endpoint added



=== Changes in shopper-baskets-oas-2.0.10 ===
1 changes: 0 error, 0 warning, 1 info
info	[endpoint-added] at apis/shopper-baskets-oas-2.0.10/shopper-baskets-oas-v2-bundled.yaml	
	in API DELETE /organizations/{organizationId}/baskets/{basketId}/coupons/{couponItemId}
		endpoint added



======shopper-orders-oas-1.4.8 API is deleted======
======shopper-stores-oas-1.0.15 API is added======
```

- Json output console
```
[
  {
    "directory": "shopper-baskets-oas-1.8.19",
    "changes": [
      {
        "id": "endpoint-added",
        "text": "endpoint added",
        "level": 1,
        "operation": "POST",
        "operationId": "createBasket",
        "path": "/organizations/{organizationId}/baskets",
        "source": "apis/shopper-baskets-oas-1.8.19/shopper-baskets-oas-v1-bundled.yaml",
        "section": "paths"
      }
    ]
  },
  {
    "directory": "shopper-baskets-oas-2.0.10",
    "changes": [
      {
        "id": "endpoint-added",
        "text": "endpoint added",
        "level": 1,
        "operation": "DELETE",
        "operationId": "removeCouponFromBasket",
        "path": "/organizations/{organizationId}/baskets/{basketId}/coupons/{couponItemId}",
        "source": "apis/shopper-baskets-oas-2.0.10/shopper-baskets-oas-v2-bundled.yaml",
        "section": "paths"
      }
    ]
  },
  {
    "directory": "shopper-orders-oas-1.4.8",
    "status": "deleted",
    "message": "shopper-orders-oas-1.4.8 API is deleted"
  },
  {
    "directory": "shopper-stores-oas-1.0.15",
    "status": "added",
    "message": "shopper-stores-oas-1.0.15 API is added"
  }
]

```